### PR TITLE
Fail gracefully if not content-type header is given.

### DIFF
--- a/lib/v1.js
+++ b/lib/v1.js
@@ -32,7 +32,7 @@ function verify(req, res) {
     const want_ct = [ 'application/x-www-form-urlencoded', 'application/json' ];
     var reason;
     try {
-      var ct = req.headers['content-type'];
+      var ct = req.headers['content-type'] || 'none';
       if (ct.indexOf(';') !== -1) {
         ct = ct.substr(0, ct.indexOf(';'));
       }

--- a/lib/v2.js
+++ b/lib/v2.js
@@ -44,10 +44,10 @@ function validateTrustedIssuers(obj) {
 function verify(req, res) {
   try {
     // content-type must be application/json
-    if (req.headers['content-type'].indexOf('application/json') !== 0) {
+    var ct = req.headers['content-type'] || 'none';
+    if (ct.indexOf('application/json') !== 0) {
       throw {
-        reason: util.format("Unsupported Content-Type: %s (expected application/json)",
-                            req.headers['content-type']),
+        reason: util.format("Unsupported Content-Type: %s (expected application/json)", ct),
         code: 415
       };
     }

--- a/tests/content-type.js
+++ b/tests/content-type.js
@@ -53,6 +53,23 @@ describe('content-type tests', function() {
     });
   });
 
+  it('(v2 api) should fail to verify when content-type is not specified', function(done) {
+    request({
+      method: 'post',
+      url: verifier.url(),
+      headers: {}
+    }, function(err, r) {
+      should.not.exist(err);
+      (r.statusCode).should.equal(415);
+      (function() {
+        r.body = JSON.parse(r.body);
+      }).should.not.throw();
+      (r.body.status).should.equal('failure');
+      (r.body.reason).should.startWith('Unsupported Content-Type: none');
+      done();
+    });
+  });
+
   it('(v1 api) should fail to verify when content-type is unsupported', function(done) {
     request({
       method: 'post',
@@ -68,6 +85,23 @@ describe('content-type tests', function() {
       }).should.not.throw();
       (r.body.status).should.equal('failure');
       (r.body.reason).should.startWith('Unsupported Content-Type: text/plain');
+      done();
+    });
+  });
+
+  it('(v1 api) should fail to verify when content-type is not specified', function(done) {
+    request({
+      method: 'post',
+      url: verifier.v1url(),
+      headers: {}
+    }, function(err, r) {
+      should.not.exist(err);
+      (r.statusCode).should.equal(415);
+      (function() {
+        r.body = JSON.parse(r.body);
+      }).should.not.throw();
+      (r.body.status).should.equal('failure');
+      (r.body.reason).should.startWith('Unsupported Content-Type: none');
       done();
     });
   });


### PR DESCRIPTION
Clients may not send any content-type header in the verification request.  We should fail, but not like this:

```
{
  "status": "failure",
  "reason": "TypeError: Cannot call method 'indexOf' of undefined"
}
```

This PR does the minimal work necessary to give a descriptive error; it may be more developer-friendly to return an explicit "Missing Content-Type header" message.
