### PR TITLE
Make toobusy max-lag a config option.

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -36,6 +36,14 @@ function loadConf() {
       default: false,
       env: "INSECURE_SSL"
     },
+    toobusy: {
+      maxLag: {
+        doc: "Max event-loop lag before toobusy reports failure",
+        format: Number,
+        default: 70,
+        env: 'TOOBUSY_MAX_LAG'
+      }
+    },
     logging: {
       formatters: {
         doc: "Formatters for intel loggers.",

--- a/lib/server.js
+++ b/lib/server.js
@@ -41,7 +41,7 @@ app.use(function(req, res, next) {
 });
 
 // return 503 when the server is too busy
-toobusy.maxLag(70 /* XXX: config */);
+toobusy.maxLag(config.get("toobusy.maxLag"));
 app.use(function(req, res, next) {
   if (toobusy()) {
     res.json({ status: "failure", reason: "too busy"}, 503);


### PR DESCRIPTION
We'd like to try tweaking this value in production to increase our CPU utilization, per discussion in https://bugzilla.mozilla.org/show_bug.cgi?id=988101.
