### PR TITLE
Pull browserid-local-verify as pinned github dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "node": ">=0.8.0"
   },
   "dependencies": {
-    "browserid-local-verify": "0.0.9",
+    "browserid-local-verify": "mozilla/browserid-local-verify#5b1c693a4013bebb765e81ecb79711e90017fb26",
     "async": "0.2.9",
     "express": "3.4.4",
     "toobusy": "0.2.4",


### PR DESCRIPTION
I'm going to merge this change so that future deployments don't accidentally use an out-of-date version of the local verifier code.
