### PR TITLE
Expose the allowURLOmission config option

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -36,6 +36,12 @@ function loadConf() {
       default: false,
       env: "INSECURE_SSL"
     },
+    allowURLOmission: {
+      doc: "(temporary hack) Allow missing URLs in support documents",
+      format: Boolean,
+      default: false,
+      env: "ALLOW_URL_OMISSION"
+    },
     toobusy: {
       maxLag: {
         doc: "Max event-loop lag before toobusy reports failure",

--- a/lib/v1.js
+++ b/lib/v1.js
@@ -11,6 +11,7 @@ util = require('util');
 
 var verifier = new Verifier({
   httpTimeout: config.get('httpTimeout'),
+  allowURLOmission: config.get('allowURLOmission'),
   insecureSSL: config.get('insecureSSL')
 });
 

--- a/lib/v2.js
+++ b/lib/v2.js
@@ -11,6 +11,7 @@ util = require('util');
 
 var verifier = new Verifier({
   httpTimeout: config.get('httpTimeout'),
+  allowURLOmission: config.get('allowURLOmission'),
   insecureSSL: config.get('insecureSSL')
 });
 


### PR DESCRIPTION
This allows the verifier to work-around a Persona bug that has
been fixed (https://github.com/mozilla/persona/pull/3982) but not
yet deployed.

Fixes #19
