### PR TITLE
first crack at a summary.log

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@
 /coverage.html
 loadtest/venv
 loadtest/*.pyc
+summary.log

--- a/lib/config.js
+++ b/lib/config.js
@@ -50,11 +50,11 @@ function loadConf() {
         env: 'LOG_FORMATTERS',
         format: Object,
         default: {
-          dev: {
-            format: "%(name)s.%(levelname)s: %(message)s",
+          pretty: {
+            format: "[%(date)s] %(name)s.%(levelname)s: %(message)s",
             colorize: true
           },
-          prod: {
+          json: {
             format: '%O'
           }
         }
@@ -65,7 +65,12 @@ function loadConf() {
         default: {
           console: {
             "class": "intel/handlers/console",
-            "formatter": "dev"
+            "formatter": "pretty"
+          },
+          summary: {
+            "class": "intel/handlers/file",
+            "file": "summary.log",
+            "formatter": "json"
           }
         }
       },
@@ -79,6 +84,10 @@ function loadConf() {
             propagate: false,
             handleExceptions: true,
             exitOnError: false
+          },
+          'bid.summary': {
+            level: 'INFO',
+            handlers: ['summary'] // will propagate to console as well
           }
         }
       }

--- a/lib/server.js
+++ b/lib/server.js
@@ -7,6 +7,7 @@ express = require('express'),
 http = require('http'),
 toobusy = require('toobusy'),
 log = require('./log').getLogger('bid.server'),
+summary = require('./summary'),
 config = require('./config'),
 v1api = require('./v1'),
 v2api = require('./v2');
@@ -73,6 +74,9 @@ app.use(function(req, res, next) {
   res.setHeader('Connection', "close");
   next();
 });
+
+// log summary - GH24
+app.use(summary());
 
 app.use(express.json({ limit: "10kb" }));
 app.use(express.urlencoded({ limit: "10kb" }));

--- a/lib/summary.js
+++ b/lib/summary.js
@@ -1,0 +1,33 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+const logger = require('./log').getLogger('bid.summary');
+
+module.exports = function middlewareFactory() {
+
+
+  return function summary(req, res, next) {
+    function log() {
+      res.removeListener('finish', log);
+      res.removeListener('close', log);
+
+      var summary = res._summary;
+      summary.code = res.statusCode;
+
+      logger.info(summary);
+    }
+
+    res._summary = {
+      api: req.url === '/v2' ? 2 : 1, // api version, /v1 or /v2
+      agent: req.headers['user-agent'],
+      host: req.headers.host,
+      v: 1 // log format version
+    };
+
+    res.on('finish', log);
+    res.on('close', log);
+
+    next();
+  };
+};

--- a/lib/v1.js
+++ b/lib/v1.js
@@ -27,6 +27,8 @@ function verify(req, res) {
   var forceIssuer = req.query.experimental_forceIssuer ? req.query.experimental_forceIssuer : req.body.experimental_forceIssuer;
   var allowUnverified = req.query.experimental_allowUnverified ? req.query.experimental_allowUnverified : req.body.experimental_allowUnverified;
 
+  res._summary.rp = audience;
+
   if (!(assertion && audience)) {
     // why couldn't we extract these guys?  Is it because the request parameters weren't encoded as we expect? GH-643
     const want_ct = [ 'application/x-www-form-urlencoded', 'application/json' ];
@@ -47,6 +49,7 @@ function verify(req, res) {
         reason: reason,
         rp: audience
       });
+      res._summary.error = e;
       return res.json({ status: "failure", reason: reason}, 415);
     }
     reason = util.format("missing %s parameter", assertion ? "audience" : "assertion");
@@ -55,6 +58,7 @@ function verify(req, res) {
       reason: reason,
       rp: audience
     });
+    res._summary.error = reason;
     return res.json({ status: "failure", reason: reason}, 400);
   }
 
@@ -72,9 +76,11 @@ function verify(req, res) {
   }, function (err, r) {
     var reqTime = new Date() - startTime;
     log.info('assertion_verification_time', reqTime);
+    res._summary.assertion_verification_time = reqTime;
 
     if (err) {
       log.info("assertion_failure");
+      res._summary.error = err;
       res.json({"status":"failure", reason: err}, 200);  //Could be 500 or 200 OK if invalid cert
       log.info('verify', {
         result: 'failure',

--- a/lib/v2.js
+++ b/lib/v2.js
@@ -53,6 +53,7 @@ function verify(req, res) {
     }
 
     req.body = req.body || {};
+    res._summary.rp = req.body.audience;
 
     // assertion and audience are required
     [ 'assertion', 'audience' ].forEach(function(field) {
@@ -76,9 +77,11 @@ function verify(req, res) {
     }, function (err, r) {
       var reqTime = new Date() - startTime;
       log.info('assertion_verification_time', reqTime);
+      res._summary.assertion_verification_time = reqTime;
 
       if (err) {
         log.info("assertion_failure");
+        res._summary.error = err;
         res.json({"status":"failure", reason: err}, 200);  //Could be 500 or 200 OK if invalid cert
         log.info('verify', {
           result: 'failure',
@@ -101,6 +104,7 @@ function verify(req, res) {
   } catch(err) {
     var reason = err.reason ? err.reason : err.toString();
 
+    res._summary.error = err;
     log.info('verify', {
       result: 'failure',
       reason: reason,


### PR DESCRIPTION
besides sending the summary stdout, it will also be logged to
(configurable) summary.log

Values:

```
{
  pid,
  timestamp,
  name = bid.summary,
  args[{
    agent, api, code, error, host, v, assertion_verification_time
  }]
 // plus others from intel, such as log level = INFO, etc
}
```

fixes #24 ?
