### PR TITLE
Remove `ass` dependency from server.js

### DIFF
--- a/server.js
+++ b/server.js
@@ -4,5 +4,4 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-require('ass');
 require('./lib/server.js');


### PR DESCRIPTION
- so we can build production deploys with `npm install --production`
- does not seem to affect any of the testing
- `ass` seems to be broken anyways w/ `npm test`
