### PR TITLE
a custom formatter for the summary format

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -61,6 +61,7 @@ function loadConf() {
             colorize: true
           },
           json: {
+            class: '../log/json',
             format: '%O'
           }
         }
@@ -96,6 +97,10 @@ function loadConf() {
             handlers: ['summary'] // will propagate to console as well
           }
         }
+      },
+      root: {
+        doc: 'Path used for finding relative classes',
+        default: __filename
       }
     }
   });
@@ -114,7 +119,8 @@ function loadConf() {
   module.exports = conf;
 
   process.nextTick(function() {
-    require('./log').getLogger('bid.config').debug("current configuration:", conf.get());
+    require('./log').getLogger('bid.config')
+      .debug("current configuration:", JSON.stringify(conf.get(), null, 2));
   });
 }
 

--- a/lib/log/index.js
+++ b/lib/log/index.js
@@ -4,4 +4,4 @@
 
 module.exports = require('intel');
 
-module.exports.config(require('./config').get('logging'));
+module.exports.config(require('../config').get('logging'));

--- a/lib/log/json.js
+++ b/lib/log/json.js
@@ -1,0 +1,27 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+const util = require('util');
+
+const intel = require('intel');
+
+function JsonFormatter(options) {
+  intel.Formatter.call(this, options);
+}
+util.inherits(JsonFormatter, intel.Formatter);
+
+JsonFormatter.prototype.format = function jsonFormat(record) {
+  // we use super.format() because intel has circular de-refencing
+  var rec = {
+    name: record.name,
+    time: record.timestamp,
+    pid: record.pid
+  };
+  for (var k in record.args[0]) {
+    rec[k] = record.args[0][k];
+  }
+  return intel.Formatter.prototype.format.call(this, rec);
+};
+
+module.exports = JsonFormatter;


### PR DESCRIPTION
It will output the first argument, plus `name`, `time`, and `pid` of the
original record, as JSON.

Fixes part of #39, where in the format will be a flat object with only the properties asked for.

However, some properties are still missing, such as `rp`, `errno`, etc.
