### PR TITLE
Remove the no-longer-needed 'allowURLOmission' flag.

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -36,12 +36,6 @@ function loadConf() {
       default: false,
       env: "INSECURE_SSL"
     },
-    allowURLOmission: {
-      doc: "(temporary hack) Allow missing URLs in support documents",
-      format: Boolean,
-      default: false,
-      env: "ALLOW_URL_OMISSION"
-    },
     toobusy: {
       maxLag: {
         doc: "Max event-loop lag before toobusy reports failure",

--- a/lib/server.js
+++ b/lib/server.js
@@ -20,7 +20,6 @@ var server = http.createServer(app);
 
 var verifier = new CCVerifier({
   httpTimeout: config.get('httpTimeout'),
-  allowURLOmission: config.get('allowURLOmission'),
   insecureSSL: config.get('insecureSSL'),
   testServiceFailure: config.get('testServiceFailure')
 });


### PR DESCRIPTION
The companion to https://github.com/mozilla/browserid-local-verify/pull/34; @fmarier r?
