### PR TITLE
Fix deprecated argument order in res.json().

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -56,7 +56,7 @@ toobusy.maxLag(config.get("toobusy.maxLag"));
 app.use(function(req, res, next) {
   if (toobusy()) {
     log.warn("too busy");
-    res.json({ status: "failure", reason: "too busy"}, 503);
+    res.json(503, { status: "failure", reason: "too busy"});
   } else {
     next();
   }

--- a/lib/v1.js
+++ b/lib/v1.js
@@ -43,7 +43,7 @@ function verify(verifier, req, res) {
         rp: audience
       });
       res._summary.err = e;
-      return res.json({ status: "failure", reason: reason}, 415);
+      return res.json(415, { status: "failure", reason: reason});
     }
     reason = util.format("missing %s parameter", assertion ? "audience" : "assertion");
     log.info('verify', {
@@ -52,7 +52,7 @@ function verify(verifier, req, res) {
       rp: audience
     });
     res._summary.err = reason;
-    return res.json({ status: "failure", reason: reason}, 400);
+    return res.json(400, { status: "failure", reason: reason});
   }
 
   var trustedIssuers = [ ];
@@ -74,10 +74,10 @@ function verify(verifier, req, res) {
     if (err) {
       if (err.indexOf("compute cluster") === 0) {
         log.info("service_failure");
-        res.json({"status":"failure", reason: "service unavailable"}, 503);
+        res.json(503, {"status":"failure", reason: "service unavailable"});
       } else {
         log.info("assertion_failure");
-        res.json({"status":"failure", reason: err}, 200);  //Could be 500 or 200 OK if invalid cert
+        res.json(200, {"status":"failure", reason: err});  //Could be 500 or 200 OK if invalid cert
       }
       res._summary.err = err;
       log.info('verify', {

--- a/lib/v2.js
+++ b/lib/v2.js
@@ -74,10 +74,10 @@ function verify(verifier, req, res) {
       if (err) {
         if (err.indexOf("compute cluster") === 0) {
           log.info("service_failure");
-          res.json({"status":"failure", reason: "service unavailable"}, 503);
+          res.json(503, {"status":"failure", reason: "service unavailable"});
         } else {
           log.info("assertion_failure");
-          res.json({"status":"failure", reason: err}, 200);  //Could be 500 or 200 OK if invalid cert
+          res.json(200, {"status":"failure", reason: err});  //Could be 500 or 200 OK if invalid cert
         }
         res._summary.err = err;
         log.info('verify', {
@@ -110,10 +110,10 @@ function verify(verifier, req, res) {
       rp: req.body.audience
     });
 
-    res.json({
+    res.json(err.code ? err.code : 500, {
       status: 'failure',
       reason: reason
-    }, err.code ? err.code : 500);
+    });
   }
 }
 


### PR DESCRIPTION
Express logs a deprecation warning when using `resp.json(obj, status)` so this fixes things to use the preferred `resp.json(status. obj)`.  @fmarier r?
