### PR TITLE
Log fields of any object args as part of top-level json log object.

### DIFF
--- a/lib/log/json.js
+++ b/lib/log/json.js
@@ -32,11 +32,17 @@ JsonFormatter.prototype.format = function jsonFormat(record) {
   for (var k in logRecordInfo) {
     rec[k] = logRecordInfo[k];
   }
-  if (typeof record.args[0] === 'string') {
-    rec.message = record.message;
-  } else {
-    for (k in record.args[0]) {
-      rec[k] = record.args[0][k];
+  for (var i = 0; i < record.args.length; i++) {
+    if (typeof record.args[i] === 'string') {
+      if (!rec.hasOwnProperty('message')) {
+        rec.message = record.args[i];
+      }
+    } else if (typeof record.args[i] === 'object') {
+      for (k in record.args[i]) {
+        if (!rec.hasOwnProperty(k)) {
+          rec[k] = record.args[i][k];
+        }
+      }
     }
   }
   return intel.Formatter.prototype.format.call(this, rec);


### PR DESCRIPTION
As noted in https://bugzilla.mozilla.org/show_bug.cgi?id=1053959#c9 we currently produce some JSON log lines that contain nested JSON along with other stuff in the "message" field.  For easier handling and PII scrubbing we should ensure that all JSON fields are logged as top-level object properties, even if there's also a string message in the log.

This produces appropriate-looking output for me.  @seanmonstar r?
