### PR TITLE
feat(docker): Dockerfile and README update for basic docker development workflow

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,11 @@
+FROM ubuntu:trusty
+
+RUN DEBIAN_FRONTEND=noninteractive apt-get -y update && DEBIAN_FRONTEND=noninteractive apt-get -y install nodejs npm
+RUN ln -sf /usr/bin/nodejs /usr/local/bin/node
+
+RUN useradd --home-dir /opt/fxa fxa
+USER fxa
+
+WORKDIR /opt/fxa
+
+CMD npm start

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ HTTP.
 
 To run the verification server via Docker, two steps are required:
 
-    $ docker build --rm -t mozilla/browserid_verifier
+    $ docker build --rm -t mozilla/browserid_verifier .
     $ docker run --rm -v $PWD:/opt/fxa mozilla/browserid_verifier npm install
     $ docker run --rm -v $PWD:/opt/fxa --net=host mozilla/browserid_verifier
 

--- a/README.md
+++ b/README.md
@@ -17,6 +17,16 @@ To run the verification server locally:
 At this point, your verifier will be running and available to use locally over
 HTTP.
 
+## Docker Based Development
+
+To run the verification server via Docker, two steps are required:
+
+    $ docker build --rm -t mozilla/browserid_verifier
+    $ docker run --rm -v $PWD:/opt/fxa mozilla/browserid_verifier npm install
+    $ docker run --rm -v $PWD:/opt/fxa --net=host mozilla/browserid_verifier
+
+This method shares the codebase into the running container so that you can install npm and various modules required by package.json. It then runs browserid-verifier in a container, while allowing you to use your IDE of choice from your normal desktop environment to develop code.
+
 ## Configuration
 
 There are several configuration variables which can change the behavior of the


### PR DESCRIPTION
I've added a dockerfile and some instructions to README.md explaining how to use Docker to develop and run browserid-verifier. It allows for development with an IDE underneath a running container as one would normally work. This means changes and running the verifier are mostly transparent to normal development. If there are any questions feel free to ask here or in IRC.