### PR TITLE
chore(tests): update code-coverage dependencies, add node 4 to travis config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ language: node_js
 node_js:
  - "0.10"
  - "0.12"
+ - "4"
 
 addons:
   apt_packages:

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -2,10 +2,415 @@
   "name": "browserid-verifier",
   "version": "0.3.0",
   "dependencies": {
+    "ass": {
+      "version": "1.0.0",
+      "from": "git://github.com/jrgm/ass.git#5be99ee7abc9fcf63f9ebcc37b151b9c822146d1",
+      "resolved": "git://github.com/jrgm/ass.git#5be99ee7abc9fcf63f9ebcc37b151b9c822146d1",
+      "dependencies": {
+        "blanket": {
+          "version": "1.1.6",
+          "from": "blanket@1.1.6",
+          "resolved": "https://registry.npmjs.org/blanket/-/blanket-1.1.6.tgz",
+          "dependencies": {
+            "esprima": {
+              "version": "1.0.4",
+              "from": "esprima@>=1.0.2 <1.1.0",
+              "resolved": "https://registry.npmjs.org/esprima/-/esprima-1.0.4.tgz"
+            },
+            "falafel": {
+              "version": "0.1.6",
+              "from": "falafel@>=0.1.6 <0.2.0",
+              "resolved": "https://registry.npmjs.org/falafel/-/falafel-0.1.6.tgz"
+            },
+            "xtend": {
+              "version": "2.1.2",
+              "from": "xtend@>=2.1.1 <2.2.0",
+              "resolved": "https://registry.npmjs.org/xtend/-/xtend-2.1.2.tgz",
+              "dependencies": {
+                "object-keys": {
+                  "version": "0.4.0",
+                  "from": "object-keys@>=0.4.0 <0.5.0",
+                  "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-0.4.0.tgz"
+                }
+              }
+            }
+          }
+        },
+        "cheerio": {
+          "version": "0.14.0",
+          "from": "cheerio@0.14.0",
+          "resolved": "https://registry.npmjs.org/cheerio/-/cheerio-0.14.0.tgz",
+          "dependencies": {
+            "htmlparser2": {
+              "version": "3.7.3",
+              "from": "htmlparser2@>=3.7.0 <3.8.0",
+              "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-3.7.3.tgz",
+              "dependencies": {
+                "domhandler": {
+                  "version": "2.2.1",
+                  "from": "domhandler@>=2.2.0 <2.3.0",
+                  "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-2.2.1.tgz"
+                },
+                "domutils": {
+                  "version": "1.5.1",
+                  "from": "domutils@>=1.5.0 <1.6.0",
+                  "resolved": "https://registry.npmjs.org/domutils/-/domutils-1.5.1.tgz",
+                  "dependencies": {
+                    "dom-serializer": {
+                      "version": "0.1.0",
+                      "from": "dom-serializer@>=0.0.0 <1.0.0",
+                      "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-0.1.0.tgz",
+                      "dependencies": {
+                        "domelementtype": {
+                          "version": "1.1.3",
+                          "from": "domelementtype@>=1.1.1 <1.2.0",
+                          "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.1.3.tgz"
+                        },
+                        "entities": {
+                          "version": "1.1.1",
+                          "from": "entities@>=1.1.1 <1.2.0",
+                          "resolved": "https://registry.npmjs.org/entities/-/entities-1.1.1.tgz"
+                        }
+                      }
+                    }
+                  }
+                },
+                "domelementtype": {
+                  "version": "1.3.0",
+                  "from": "domelementtype@>=1.0.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.3.0.tgz"
+                },
+                "readable-stream": {
+                  "version": "1.1.13",
+                  "from": "readable-stream@>=1.1.0 <1.2.0",
+                  "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz",
+                  "dependencies": {
+                    "core-util-is": {
+                      "version": "1.0.2",
+                      "from": "core-util-is@>=1.0.0 <1.1.0",
+                      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
+                    },
+                    "isarray": {
+                      "version": "0.0.1",
+                      "from": "isarray@0.0.1",
+                      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                    },
+                    "string_decoder": {
+                      "version": "0.10.31",
+                      "from": "string_decoder@>=0.10.0 <0.11.0",
+                      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+                    },
+                    "inherits": {
+                      "version": "2.0.1",
+                      "from": "inherits@>=2.0.1 <2.1.0",
+                      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                    }
+                  }
+                }
+              }
+            },
+            "entities": {
+              "version": "1.0.0",
+              "from": "entities@>=1.0.0 <1.1.0",
+              "resolved": "https://registry.npmjs.org/entities/-/entities-1.0.0.tgz"
+            },
+            "CSSselect": {
+              "version": "0.4.1",
+              "from": "CSSselect@>=0.4.0 <0.5.0",
+              "resolved": "https://registry.npmjs.org/CSSselect/-/CSSselect-0.4.1.tgz",
+              "dependencies": {
+                "CSSwhat": {
+                  "version": "0.4.7",
+                  "from": "CSSwhat@>=0.4.0 <0.5.0",
+                  "resolved": "https://registry.npmjs.org/CSSwhat/-/CSSwhat-0.4.7.tgz"
+                },
+                "domutils": {
+                  "version": "1.4.3",
+                  "from": "domutils@>=1.4.0 <1.5.0",
+                  "resolved": "https://registry.npmjs.org/domutils/-/domutils-1.4.3.tgz",
+                  "dependencies": {
+                    "domelementtype": {
+                      "version": "1.3.0",
+                      "from": "domelementtype@>=1.0.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.3.0.tgz"
+                    }
+                  }
+                }
+              }
+            },
+            "lodash": {
+              "version": "2.4.2",
+              "from": "lodash@>=2.4.1 <2.5.0",
+              "resolved": "https://registry.npmjs.org/lodash/-/lodash-2.4.2.tgz"
+            }
+          }
+        },
+        "temp": {
+          "version": "0.8.1",
+          "from": "temp@0.8.1",
+          "resolved": "https://registry.npmjs.org/temp/-/temp-0.8.1.tgz",
+          "dependencies": {
+            "rimraf": {
+              "version": "2.2.8",
+              "from": "rimraf@>=2.2.6 <2.3.0",
+              "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.2.8.tgz"
+            }
+          }
+        }
+      }
+    },
     "async": {
       "version": "0.9.0",
       "from": "async@0.9.0",
       "resolved": "https://registry.npmjs.org/async/-/async-0.9.0.tgz"
+    },
+    "awsbox": {
+      "version": "0.7.0",
+      "from": "awsbox@0.7.0",
+      "resolved": "https://registry.npmjs.org/awsbox/-/awsbox-0.7.0.tgz",
+      "dependencies": {
+        "awssum-amazon-ec2": {
+          "version": "1.5.0",
+          "from": "awssum-amazon-ec2@>=1.3.2",
+          "resolved": "https://registry.npmjs.org/awssum-amazon-ec2/-/awssum-amazon-ec2-1.5.0.tgz",
+          "dependencies": {
+            "data2xml": {
+              "version": "0.8.1",
+              "from": "data2xml@>=0.8.0 <0.9.0",
+              "resolved": "https://registry.npmjs.org/data2xml/-/data2xml-0.8.1.tgz"
+            },
+            "underscore": {
+              "version": "1.4.4",
+              "from": "underscore@>=1.4.0 <1.5.0",
+              "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.4.4.tgz"
+            },
+            "dateformat": {
+              "version": "1.0.4-1.2.3",
+              "from": "dateformat@1.0.4-1.2.3",
+              "resolved": "https://registry.npmjs.org/dateformat/-/dateformat-1.0.4-1.2.3.tgz"
+            }
+          }
+        },
+        "awssum-amazon-route53": {
+          "version": "1.2.0",
+          "from": "awssum-amazon-route53@>=1.0.0 <2.0.0",
+          "resolved": "https://registry.npmjs.org/awssum-amazon-route53/-/awssum-amazon-route53-1.2.0.tgz",
+          "dependencies": {
+            "fmt": {
+              "version": "0.4.0",
+              "from": "fmt@>=0.4.0 <0.5.0",
+              "resolved": "https://registry.npmjs.org/fmt/-/fmt-0.4.0.tgz"
+            },
+            "data2xml": {
+              "version": "0.8.1",
+              "from": "data2xml@>=0.8.0 <0.9.0",
+              "resolved": "https://registry.npmjs.org/data2xml/-/data2xml-0.8.1.tgz"
+            },
+            "underscore": {
+              "version": "1.4.4",
+              "from": "underscore@>=1.4.0 <1.5.0",
+              "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.4.4.tgz"
+            },
+            "dateformat": {
+              "version": "1.0.4-1.2.3",
+              "from": "dateformat@1.0.4-1.2.3",
+              "resolved": "https://registry.npmjs.org/dateformat/-/dateformat-1.0.4-1.2.3.tgz"
+            }
+          }
+        },
+        "nice-route53": {
+          "version": "0.3.4",
+          "from": "nice-route53@0.3.4",
+          "resolved": "https://registry.npmjs.org/nice-route53/-/nice-route53-0.3.4.tgz",
+          "dependencies": {
+            "awssum-amazon-route53": {
+              "version": "1.0.3",
+              "from": "awssum-amazon-route53@>=1.0.0 <1.1.0",
+              "resolved": "https://registry.npmjs.org/awssum-amazon-route53/-/awssum-amazon-route53-1.0.3.tgz",
+              "dependencies": {
+                "fmt": {
+                  "version": "0.4.0",
+                  "from": "fmt@>=0.4.0 <0.5.0",
+                  "resolved": "https://registry.npmjs.org/fmt/-/fmt-0.4.0.tgz"
+                },
+                "data2xml": {
+                  "version": "0.8.1",
+                  "from": "data2xml@>=0.8.0 <0.9.0",
+                  "resolved": "https://registry.npmjs.org/data2xml/-/data2xml-0.8.1.tgz"
+                },
+                "underscore": {
+                  "version": "1.4.4",
+                  "from": "underscore@>=1.4.0 <1.5.0",
+                  "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.4.4.tgz"
+                },
+                "dateformat": {
+                  "version": "1.0.4-1.2.3",
+                  "from": "dateformat@1.0.4-1.2.3",
+                  "resolved": "https://registry.npmjs.org/dateformat/-/dateformat-1.0.4-1.2.3.tgz"
+                }
+              }
+            }
+          }
+        },
+        "async": {
+          "version": "0.2.10",
+          "from": "async@>=0.2.0 <0.3.0",
+          "resolved": "https://registry.npmjs.org/async/-/async-0.2.10.tgz"
+        },
+        "JSONSelect": {
+          "version": "0.4.0",
+          "from": "JSONSelect@0.4.0",
+          "resolved": "https://registry.npmjs.org/JSONSelect/-/JSONSelect-0.4.0.tgz"
+        },
+        "temp": {
+          "version": "0.4.0",
+          "from": "temp@0.4.0",
+          "resolved": "https://registry.npmjs.org/temp/-/temp-0.4.0.tgz"
+        },
+        "xml2js": {
+          "version": "0.1.13",
+          "from": "xml2js@0.1.13",
+          "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.1.13.tgz",
+          "dependencies": {
+            "sax": {
+              "version": "1.1.4",
+              "from": "sax@>=0.1.1",
+              "resolved": "https://registry.npmjs.org/sax/-/sax-1.1.4.tgz"
+            }
+          }
+        },
+        "optimist": {
+          "version": "0.3.1",
+          "from": "optimist@0.3.1",
+          "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.3.1.tgz",
+          "dependencies": {
+            "wordwrap": {
+              "version": "0.0.3",
+              "from": "wordwrap@>=0.0.1 <0.1.0",
+              "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz"
+            }
+          }
+        },
+        "urlparse": {
+          "version": "0.0.1",
+          "from": "urlparse@0.0.1",
+          "resolved": "https://registry.npmjs.org/urlparse/-/urlparse-0.0.1.tgz"
+        },
+        "relative-date": {
+          "version": "1.1.1",
+          "from": "relative-date@1.1.1",
+          "resolved": "https://registry.npmjs.org/relative-date/-/relative-date-1.1.1.tgz"
+        },
+        "colors": {
+          "version": "0.6.2",
+          "from": "colors@>=0.6.0-1 <0.7.0",
+          "resolved": "https://registry.npmjs.org/colors/-/colors-0.6.2.tgz"
+        },
+        "awssum": {
+          "version": "1.1.0",
+          "from": "awssum@1.1.0",
+          "resolved": "https://registry.npmjs.org/awssum/-/awssum-1.1.0.tgz",
+          "dependencies": {
+            "underscore": {
+              "version": "1.4.4",
+              "from": "underscore@>=1.4.0 <1.5.0",
+              "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.4.4.tgz"
+            },
+            "xml2js": {
+              "version": "0.2.8",
+              "from": "xml2js@>=0.2.0 <0.3.0",
+              "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.2.8.tgz",
+              "dependencies": {
+                "sax": {
+                  "version": "0.5.8",
+                  "from": "sax@>=0.5.0 <0.6.0",
+                  "resolved": "https://registry.npmjs.org/sax/-/sax-0.5.8.tgz"
+                }
+              }
+            }
+          }
+        },
+        "awssum-amazon": {
+          "version": "1.1.0",
+          "from": "awssum-amazon@1.1.0",
+          "resolved": "https://registry.npmjs.org/awssum-amazon/-/awssum-amazon-1.1.0.tgz",
+          "dependencies": {
+            "underscore": {
+              "version": "1.4.4",
+              "from": "underscore@>=1.4.0 <1.5.0",
+              "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.4.4.tgz"
+            },
+            "dateformat": {
+              "version": "1.0.4-1.2.3",
+              "from": "dateformat@1.0.4-1.2.3",
+              "resolved": "https://registry.npmjs.org/dateformat/-/dateformat-1.0.4-1.2.3.tgz"
+            }
+          }
+        },
+        "read-package-json": {
+          "version": "1.1.9",
+          "from": "read-package-json@>=1.1.3 <1.2.0",
+          "resolved": "https://registry.npmjs.org/read-package-json/-/read-package-json-1.1.9.tgz",
+          "dependencies": {
+            "glob": {
+              "version": "3.2.11",
+              "from": "glob@>=3.2.1 <3.3.0",
+              "resolved": "https://registry.npmjs.org/glob/-/glob-3.2.11.tgz",
+              "dependencies": {
+                "inherits": {
+                  "version": "2.0.1",
+                  "from": "inherits@>=2.0.0 <3.0.0",
+                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                },
+                "minimatch": {
+                  "version": "0.3.0",
+                  "from": "minimatch@>=0.3.0 <0.4.0",
+                  "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.3.0.tgz",
+                  "dependencies": {
+                    "sigmund": {
+                      "version": "1.0.1",
+                      "from": "sigmund@>=1.0.0 <1.1.0",
+                      "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz"
+                    }
+                  }
+                }
+              }
+            },
+            "lru-cache": {
+              "version": "2.7.3",
+              "from": "lru-cache@>=2.0.0 <3.0.0",
+              "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.7.3.tgz"
+            },
+            "normalize-package-data": {
+              "version": "0.2.13",
+              "from": "normalize-package-data@>=0.2.13 <0.3.0",
+              "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-0.2.13.tgz",
+              "dependencies": {
+                "github-url-from-git": {
+                  "version": "1.1.1",
+                  "from": "github-url-from-git@>=1.1.1 <1.2.0",
+                  "resolved": "https://registry.npmjs.org/github-url-from-git/-/github-url-from-git-1.1.1.tgz"
+                },
+                "github-url-from-username-repo": {
+                  "version": "0.1.0",
+                  "from": "github-url-from-username-repo@>=0.1.0 <0.2.0",
+                  "resolved": "https://registry.npmjs.org/github-url-from-username-repo/-/github-url-from-username-repo-0.1.0.tgz"
+                },
+                "semver": {
+                  "version": "2.3.2",
+                  "from": "semver@>=2.0.0 <3.0.0",
+                  "resolved": "https://registry.npmjs.org/semver/-/semver-2.3.2.tgz"
+                }
+              }
+            },
+            "graceful-fs": {
+              "version": "2.0.3",
+              "from": "graceful-fs@>=2.0.0 <3.0.0",
+              "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-2.0.3.tgz"
+            }
+          }
+        }
+      }
     },
     "browserid-local-verify": {
       "version": "0.1.0",
@@ -65,9 +470,9 @@
                               "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.3.0.tgz",
                               "dependencies": {
                                 "amdefine": {
-                                  "version": "0.1.1",
+                                  "version": "1.0.0",
                                   "from": "amdefine@>=0.0.4",
-                                  "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-0.1.1.tgz"
+                                  "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.0.tgz"
                                 }
                               }
                             }
@@ -84,9 +489,9 @@
                           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.43.tgz",
                           "dependencies": {
                             "amdefine": {
-                              "version": "0.1.1",
+                              "version": "1.0.0",
                               "from": "amdefine@>=0.0.4",
-                              "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-0.1.1.tgz"
+                              "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.0.tgz"
                             }
                           }
                         }
@@ -103,9 +508,9 @@
                           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
                           "dependencies": {
                             "core-util-is": {
-                              "version": "1.0.1",
+                              "version": "1.0.2",
                               "from": "core-util-is@>=1.0.0 <1.1.0",
-                              "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
+                              "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
                             },
                             "string_decoder": {
                               "version": "0.10.31",
@@ -119,9 +524,9 @@
                   }
                 },
                 "browser-resolve": {
-                  "version": "1.9.0",
+                  "version": "1.11.0",
                   "from": "browser-resolve@>=1.3.0 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/browser-resolve/-/browser-resolve-1.9.0.tgz",
+                  "resolved": "https://registry.npmjs.org/browser-resolve/-/browser-resolve-1.11.0.tgz",
                   "dependencies": {
                     "resolve": {
                       "version": "1.1.6",
@@ -136,9 +541,9 @@
                   "resolved": "https://registry.npmjs.org/browserify-zlib/-/browserify-zlib-0.1.4.tgz",
                   "dependencies": {
                     "pako": {
-                      "version": "0.2.7",
+                      "version": "0.2.8",
                       "from": "pako@>=0.2.0 <0.3.0",
-                      "resolved": "https://registry.npmjs.org/pako/-/pako-0.2.7.tgz"
+                      "resolved": "https://registry.npmjs.org/pako/-/pako-0.2.8.tgz"
                     }
                   }
                 },
@@ -188,7 +593,7 @@
                 },
                 "console-browserify": {
                   "version": "1.1.0",
-                  "from": "console-browserify@>=1.1.0 <1.2.0",
+                  "from": "console-browserify@>=1.1.0 <2.0.0",
                   "resolved": "https://registry.npmjs.org/console-browserify/-/console-browserify-1.1.0.tgz",
                   "dependencies": {
                     "date-now": {
@@ -204,34 +609,82 @@
                   "resolved": "https://registry.npmjs.org/constants-browserify/-/constants-browserify-0.0.1.tgz"
                 },
                 "crypto-browserify": {
-                  "version": "3.9.14",
+                  "version": "3.11.0",
                   "from": "crypto-browserify@>=3.0.0 <4.0.0",
-                  "resolved": "https://registry.npmjs.org/crypto-browserify/-/crypto-browserify-3.9.14.tgz",
+                  "resolved": "https://registry.npmjs.org/crypto-browserify/-/crypto-browserify-3.11.0.tgz",
                   "dependencies": {
-                    "browserify-aes": {
-                      "version": "1.0.1",
-                      "from": "browserify-aes@>=1.0.0 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/browserify-aes/-/browserify-aes-1.0.1.tgz"
+                    "browserify-cipher": {
+                      "version": "1.0.0",
+                      "from": "browserify-cipher@>=1.0.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/browserify-cipher/-/browserify-cipher-1.0.0.tgz",
+                      "dependencies": {
+                        "browserify-aes": {
+                          "version": "1.0.5",
+                          "from": "browserify-aes@>=1.0.4 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/browserify-aes/-/browserify-aes-1.0.5.tgz",
+                          "dependencies": {
+                            "buffer-xor": {
+                              "version": "1.0.3",
+                              "from": "buffer-xor@>=1.0.2 <2.0.0",
+                              "resolved": "https://registry.npmjs.org/buffer-xor/-/buffer-xor-1.0.3.tgz"
+                            },
+                            "cipher-base": {
+                              "version": "1.0.2",
+                              "from": "cipher-base@>=1.0.0 <2.0.0",
+                              "resolved": "https://registry.npmjs.org/cipher-base/-/cipher-base-1.0.2.tgz"
+                            }
+                          }
+                        },
+                        "browserify-des": {
+                          "version": "1.0.0",
+                          "from": "browserify-des@>=1.0.0 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/browserify-des/-/browserify-des-1.0.0.tgz",
+                          "dependencies": {
+                            "cipher-base": {
+                              "version": "1.0.2",
+                              "from": "cipher-base@>=1.0.1 <2.0.0",
+                              "resolved": "https://registry.npmjs.org/cipher-base/-/cipher-base-1.0.2.tgz"
+                            },
+                            "des.js": {
+                              "version": "1.0.0",
+                              "from": "des.js@>=1.0.0 <2.0.0",
+                              "resolved": "https://registry.npmjs.org/des.js/-/des.js-1.0.0.tgz",
+                              "dependencies": {
+                                "minimalistic-assert": {
+                                  "version": "1.0.0",
+                                  "from": "minimalistic-assert@>=1.0.0 <2.0.0",
+                                  "resolved": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.0.tgz"
+                                }
+                              }
+                            }
+                          }
+                        },
+                        "evp_bytestokey": {
+                          "version": "1.0.0",
+                          "from": "evp_bytestokey@>=1.0.0 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/evp_bytestokey/-/evp_bytestokey-1.0.0.tgz"
+                        }
+                      }
                     },
                     "browserify-sign": {
-                      "version": "3.0.2",
-                      "from": "browserify-sign@>=3.0.1 <4.0.0",
-                      "resolved": "https://registry.npmjs.org/browserify-sign/-/browserify-sign-3.0.2.tgz",
+                      "version": "4.0.0",
+                      "from": "browserify-sign@>=4.0.0 <5.0.0",
+                      "resolved": "https://registry.npmjs.org/browserify-sign/-/browserify-sign-4.0.0.tgz",
                       "dependencies": {
                         "bn.js": {
-                          "version": "2.2.0",
-                          "from": "bn.js@>=2.0.0 <3.0.0",
-                          "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-2.2.0.tgz"
+                          "version": "4.6.2",
+                          "from": "bn.js@>=4.1.0 <5.0.0",
+                          "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.6.2.tgz"
                         },
                         "browserify-rsa": {
-                          "version": "2.0.1",
-                          "from": "browserify-rsa@>=2.0.0 <3.0.0",
-                          "resolved": "https://registry.npmjs.org/browserify-rsa/-/browserify-rsa-2.0.1.tgz"
+                          "version": "4.0.0",
+                          "from": "browserify-rsa@>=4.0.0 <5.0.0",
+                          "resolved": "https://registry.npmjs.org/browserify-rsa/-/browserify-rsa-4.0.0.tgz"
                         },
                         "elliptic": {
-                          "version": "3.1.0",
-                          "from": "elliptic@>=3.0.0 <4.0.0",
-                          "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-3.1.0.tgz",
+                          "version": "6.0.2",
+                          "from": "elliptic@>=6.0.0 <7.0.0",
+                          "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.0.2.tgz",
                           "dependencies": {
                             "brorand": {
                               "version": "1.0.5",
@@ -246,14 +699,14 @@
                           }
                         },
                         "parse-asn1": {
-                          "version": "3.0.1",
-                          "from": "parse-asn1@>=3.0.0 <4.0.0",
-                          "resolved": "https://registry.npmjs.org/parse-asn1/-/parse-asn1-3.0.1.tgz",
+                          "version": "5.0.0",
+                          "from": "parse-asn1@>=5.0.0 <6.0.0",
+                          "resolved": "https://registry.npmjs.org/parse-asn1/-/parse-asn1-5.0.0.tgz",
                           "dependencies": {
                             "asn1.js": {
-                              "version": "2.1.2",
-                              "from": "asn1.js@>=2.0.0 <3.0.0",
-                              "resolved": "https://registry.npmjs.org/asn1.js/-/asn1.js-2.1.2.tgz",
+                              "version": "4.3.0",
+                              "from": "asn1.js@>=4.0.0 <5.0.0",
+                              "resolved": "https://registry.npmjs.org/asn1.js/-/asn1.js-4.3.0.tgz",
                               "dependencies": {
                                 "minimalistic-assert": {
                                   "version": "1.0.0",
@@ -261,25 +714,47 @@
                                   "resolved": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.0.tgz"
                                 }
                               }
+                            },
+                            "browserify-aes": {
+                              "version": "1.0.5",
+                              "from": "browserify-aes@>=1.0.0 <2.0.0",
+                              "resolved": "https://registry.npmjs.org/browserify-aes/-/browserify-aes-1.0.5.tgz",
+                              "dependencies": {
+                                "buffer-xor": {
+                                  "version": "1.0.3",
+                                  "from": "buffer-xor@>=1.0.2 <2.0.0",
+                                  "resolved": "https://registry.npmjs.org/buffer-xor/-/buffer-xor-1.0.3.tgz"
+                                },
+                                "cipher-base": {
+                                  "version": "1.0.2",
+                                  "from": "cipher-base@>=1.0.0 <2.0.0",
+                                  "resolved": "https://registry.npmjs.org/cipher-base/-/cipher-base-1.0.2.tgz"
+                                }
+                              }
+                            },
+                            "evp_bytestokey": {
+                              "version": "1.0.0",
+                              "from": "evp_bytestokey@>=1.0.0 <2.0.0",
+                              "resolved": "https://registry.npmjs.org/evp_bytestokey/-/evp_bytestokey-1.0.0.tgz"
                             }
                           }
                         }
                       }
                     },
                     "create-ecdh": {
-                      "version": "2.0.1",
-                      "from": "create-ecdh@>=2.0.0 <3.0.0",
-                      "resolved": "https://registry.npmjs.org/create-ecdh/-/create-ecdh-2.0.1.tgz",
+                      "version": "4.0.0",
+                      "from": "create-ecdh@>=4.0.0 <5.0.0",
+                      "resolved": "https://registry.npmjs.org/create-ecdh/-/create-ecdh-4.0.0.tgz",
                       "dependencies": {
                         "bn.js": {
-                          "version": "2.2.0",
-                          "from": "bn.js@>=2.0.0 <3.0.0",
-                          "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-2.2.0.tgz"
+                          "version": "4.6.2",
+                          "from": "bn.js@>=4.1.0 <5.0.0",
+                          "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.6.2.tgz"
                         },
                         "elliptic": {
-                          "version": "3.1.0",
-                          "from": "elliptic@>=3.0.0 <4.0.0",
-                          "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-3.1.0.tgz",
+                          "version": "6.0.2",
+                          "from": "elliptic@>=6.0.0 <7.0.0",
+                          "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.0.2.tgz",
                           "dependencies": {
                             "brorand": {
                               "version": "1.0.5",
@@ -296,41 +771,46 @@
                       }
                     },
                     "create-hash": {
-                      "version": "1.1.1",
+                      "version": "1.1.2",
                       "from": "create-hash@>=1.1.0 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/create-hash/-/create-hash-1.1.1.tgz",
+                      "resolved": "https://registry.npmjs.org/create-hash/-/create-hash-1.1.2.tgz",
                       "dependencies": {
+                        "cipher-base": {
+                          "version": "1.0.2",
+                          "from": "cipher-base@>=1.0.1 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/cipher-base/-/cipher-base-1.0.2.tgz"
+                        },
                         "ripemd160": {
                           "version": "1.0.1",
                           "from": "ripemd160@>=1.0.0 <2.0.0",
                           "resolved": "https://registry.npmjs.org/ripemd160/-/ripemd160-1.0.1.tgz"
                         },
                         "sha.js": {
-                          "version": "2.4.2",
+                          "version": "2.4.4",
                           "from": "sha.js@>=2.3.6 <3.0.0",
-                          "resolved": "https://registry.npmjs.org/sha.js/-/sha.js-2.4.2.tgz"
+                          "resolved": "https://registry.npmjs.org/sha.js/-/sha.js-2.4.4.tgz"
                         }
                       }
                     },
                     "create-hmac": {
-                      "version": "1.1.3",
+                      "version": "1.1.4",
                       "from": "create-hmac@>=1.1.0 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/create-hmac/-/create-hmac-1.1.3.tgz"
+                      "resolved": "https://registry.npmjs.org/create-hmac/-/create-hmac-1.1.4.tgz"
                     },
                     "diffie-hellman": {
-                      "version": "3.0.2",
-                      "from": "diffie-hellman@>=3.0.1 <4.0.0",
-                      "resolved": "https://registry.npmjs.org/diffie-hellman/-/diffie-hellman-3.0.2.tgz",
+                      "version": "5.0.0",
+                      "from": "diffie-hellman@>=5.0.0 <6.0.0",
+                      "resolved": "https://registry.npmjs.org/diffie-hellman/-/diffie-hellman-5.0.0.tgz",
                       "dependencies": {
                         "bn.js": {
-                          "version": "2.2.0",
-                          "from": "bn.js@>=2.0.0 <3.0.0",
-                          "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-2.2.0.tgz"
+                          "version": "4.6.2",
+                          "from": "bn.js@>=4.1.0 <5.0.0",
+                          "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.6.2.tgz"
                         },
                         "miller-rabin": {
-                          "version": "2.0.1",
-                          "from": "miller-rabin@>=2.0.0 <3.0.0",
-                          "resolved": "https://registry.npmjs.org/miller-rabin/-/miller-rabin-2.0.1.tgz",
+                          "version": "4.0.0",
+                          "from": "miller-rabin@>=4.0.0 <5.0.0",
+                          "resolved": "https://registry.npmjs.org/miller-rabin/-/miller-rabin-4.0.0.tgz",
                           "dependencies": {
                             "brorand": {
                               "version": "1.0.5",
@@ -347,29 +827,29 @@
                       "resolved": "https://registry.npmjs.org/pbkdf2/-/pbkdf2-3.0.4.tgz"
                     },
                     "public-encrypt": {
-                      "version": "2.0.1",
-                      "from": "public-encrypt@>=2.0.0 <3.0.0",
-                      "resolved": "https://registry.npmjs.org/public-encrypt/-/public-encrypt-2.0.1.tgz",
+                      "version": "4.0.0",
+                      "from": "public-encrypt@>=4.0.0 <5.0.0",
+                      "resolved": "https://registry.npmjs.org/public-encrypt/-/public-encrypt-4.0.0.tgz",
                       "dependencies": {
                         "bn.js": {
-                          "version": "2.2.0",
-                          "from": "bn.js@>=2.0.0 <3.0.0",
-                          "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-2.2.0.tgz"
+                          "version": "4.6.2",
+                          "from": "bn.js@>=4.1.0 <5.0.0",
+                          "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.6.2.tgz"
                         },
                         "browserify-rsa": {
-                          "version": "2.0.1",
-                          "from": "browserify-rsa@>=2.0.0 <3.0.0",
-                          "resolved": "https://registry.npmjs.org/browserify-rsa/-/browserify-rsa-2.0.1.tgz"
+                          "version": "4.0.0",
+                          "from": "browserify-rsa@>=4.0.0 <5.0.0",
+                          "resolved": "https://registry.npmjs.org/browserify-rsa/-/browserify-rsa-4.0.0.tgz"
                         },
                         "parse-asn1": {
-                          "version": "3.0.1",
-                          "from": "parse-asn1@>=3.0.0 <4.0.0",
-                          "resolved": "https://registry.npmjs.org/parse-asn1/-/parse-asn1-3.0.1.tgz",
+                          "version": "5.0.0",
+                          "from": "parse-asn1@>=5.0.0 <6.0.0",
+                          "resolved": "https://registry.npmjs.org/parse-asn1/-/parse-asn1-5.0.0.tgz",
                           "dependencies": {
                             "asn1.js": {
-                              "version": "2.1.2",
-                              "from": "asn1.js@>=2.0.0 <3.0.0",
-                              "resolved": "https://registry.npmjs.org/asn1.js/-/asn1.js-2.1.2.tgz",
+                              "version": "4.3.0",
+                              "from": "asn1.js@>=4.0.0 <5.0.0",
+                              "resolved": "https://registry.npmjs.org/asn1.js/-/asn1.js-4.3.0.tgz",
                               "dependencies": {
                                 "minimalistic-assert": {
                                   "version": "1.0.0",
@@ -377,6 +857,28 @@
                                   "resolved": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.0.tgz"
                                 }
                               }
+                            },
+                            "browserify-aes": {
+                              "version": "1.0.5",
+                              "from": "browserify-aes@>=1.0.0 <2.0.0",
+                              "resolved": "https://registry.npmjs.org/browserify-aes/-/browserify-aes-1.0.5.tgz",
+                              "dependencies": {
+                                "buffer-xor": {
+                                  "version": "1.0.3",
+                                  "from": "buffer-xor@>=1.0.2 <2.0.0",
+                                  "resolved": "https://registry.npmjs.org/buffer-xor/-/buffer-xor-1.0.3.tgz"
+                                },
+                                "cipher-base": {
+                                  "version": "1.0.2",
+                                  "from": "cipher-base@>=1.0.0 <2.0.0",
+                                  "resolved": "https://registry.npmjs.org/cipher-base/-/cipher-base-1.0.2.tgz"
+                                }
+                              }
+                            },
+                            "evp_bytestokey": {
+                              "version": "1.0.0",
+                              "from": "evp_bytestokey@>=1.0.0 <2.0.0",
+                              "resolved": "https://registry.npmjs.org/evp_bytestokey/-/evp_bytestokey-1.0.0.tgz"
                             }
                           }
                         }
@@ -405,14 +907,14 @@
                   "resolved": "https://registry.npmjs.org/deps-sort/-/deps-sort-1.3.9.tgz",
                   "dependencies": {
                     "JSONStream": {
-                      "version": "1.0.4",
+                      "version": "1.0.7",
                       "from": "JSONStream@>=1.0.3 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-1.0.4.tgz",
+                      "resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-1.0.7.tgz",
                       "dependencies": {
                         "jsonparse": {
-                          "version": "1.0.0",
-                          "from": "jsonparse@>=1.0.0 <1.1.0",
-                          "resolved": "https://registry.npmjs.org/jsonparse/-/jsonparse-1.0.0.tgz"
+                          "version": "1.2.0",
+                          "from": "jsonparse@>=1.1.0 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/jsonparse/-/jsonparse-1.2.0.tgz"
                         },
                         "through": {
                           "version": "2.3.8",
@@ -427,18 +929,18 @@
                       "resolved": "https://registry.npmjs.org/subarg/-/subarg-1.0.0.tgz",
                       "dependencies": {
                         "minimist": {
-                          "version": "1.1.1",
+                          "version": "1.2.0",
                           "from": "minimist@>=1.1.0 <2.0.0",
-                          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.1.1.tgz"
+                          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz"
                         }
                       }
                     }
                   }
                 },
                 "domain-browser": {
-                  "version": "1.1.4",
+                  "version": "1.1.7",
                   "from": "domain-browser@>=1.1.0 <1.2.0",
-                  "resolved": "https://registry.npmjs.org/domain-browser/-/domain-browser-1.1.4.tgz"
+                  "resolved": "https://registry.npmjs.org/domain-browser/-/domain-browser-1.1.7.tgz"
                 },
                 "duplexer2": {
                   "version": "0.0.2",
@@ -452,7 +954,7 @@
                 },
                 "glob": {
                   "version": "3.2.11",
-                  "from": "glob@>=3.2.1 <3.3.0",
+                  "from": "glob@>=3.2.8 <3.3.0",
                   "resolved": "https://registry.npmjs.org/glob/-/glob-3.2.11.tgz",
                   "dependencies": {
                     "minimatch": {
@@ -461,9 +963,9 @@
                       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.3.0.tgz",
                       "dependencies": {
                         "lru-cache": {
-                          "version": "2.6.5",
+                          "version": "2.7.3",
                           "from": "lru-cache@>=2.0.0 <3.0.0",
-                          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.6.5.tgz"
+                          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.7.3.tgz"
                         },
                         "sigmund": {
                           "version": "1.0.1",
@@ -475,29 +977,29 @@
                   }
                 },
                 "https-browserify": {
-                  "version": "0.0.0",
+                  "version": "0.0.1",
                   "from": "https-browserify@>=0.0.0 <0.1.0",
-                  "resolved": "https://registry.npmjs.org/https-browserify/-/https-browserify-0.0.0.tgz"
+                  "resolved": "https://registry.npmjs.org/https-browserify/-/https-browserify-0.0.1.tgz"
                 },
                 "inherits": {
                   "version": "2.0.1",
-                  "from": "inherits@>=2.0.0 <3.0.0",
+                  "from": "inherits@>=2.0.1 <2.1.0",
                   "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                 },
                 "insert-module-globals": {
-                  "version": "6.5.2",
+                  "version": "6.6.3",
                   "from": "insert-module-globals@>=6.1.0 <7.0.0",
-                  "resolved": "https://registry.npmjs.org/insert-module-globals/-/insert-module-globals-6.5.2.tgz",
+                  "resolved": "https://registry.npmjs.org/insert-module-globals/-/insert-module-globals-6.6.3.tgz",
                   "dependencies": {
                     "JSONStream": {
-                      "version": "1.0.4",
+                      "version": "1.0.7",
                       "from": "JSONStream@>=1.0.3 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-1.0.4.tgz",
+                      "resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-1.0.7.tgz",
                       "dependencies": {
                         "jsonparse": {
-                          "version": "1.0.0",
-                          "from": "jsonparse@>=1.0.0 <1.1.0",
-                          "resolved": "https://registry.npmjs.org/jsonparse/-/jsonparse-1.0.0.tgz"
+                          "version": "1.2.0",
+                          "from": "jsonparse@>=1.1.0 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/jsonparse/-/jsonparse-1.2.0.tgz"
                         },
                         "through": {
                           "version": "2.3.8",
@@ -512,9 +1014,9 @@
                       "resolved": "https://registry.npmjs.org/combine-source-map/-/combine-source-map-0.6.1.tgz",
                       "dependencies": {
                         "convert-source-map": {
-                          "version": "1.1.1",
+                          "version": "1.1.3",
                           "from": "convert-source-map@>=1.1.0 <1.2.0",
-                          "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.1.1.tgz"
+                          "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.1.3.tgz"
                         },
                         "inline-source-map": {
                           "version": "0.5.0",
@@ -527,23 +1029,28 @@
                           "resolved": "https://registry.npmjs.org/lodash.memoize/-/lodash.memoize-3.0.4.tgz"
                         },
                         "source-map": {
-                          "version": "0.4.3",
+                          "version": "0.4.4",
                           "from": "source-map@>=0.4.2 <0.5.0",
-                          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.4.3.tgz",
+                          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz",
                           "dependencies": {
                             "amdefine": {
-                              "version": "0.1.1",
+                              "version": "1.0.0",
                               "from": "amdefine@>=0.0.4",
-                              "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-0.1.1.tgz"
+                              "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.0.tgz"
                             }
                           }
                         }
                       }
                     },
-                    "lexical-scope": {
+                    "is-buffer": {
                       "version": "1.1.1",
-                      "from": "lexical-scope@>=1.1.0 <1.2.0",
-                      "resolved": "https://registry.npmjs.org/lexical-scope/-/lexical-scope-1.1.1.tgz",
+                      "from": "is-buffer@>=1.1.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.1.tgz"
+                    },
+                    "lexical-scope": {
+                      "version": "1.2.0",
+                      "from": "lexical-scope@>=1.2.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/lexical-scope/-/lexical-scope-1.2.0.tgz",
                       "dependencies": {
                         "astw": {
                           "version": "2.0.0",
@@ -560,14 +1067,14 @@
                       }
                     },
                     "process": {
-                      "version": "0.11.1",
+                      "version": "0.11.2",
                       "from": "process@>=0.11.0 <0.12.0",
-                      "resolved": "https://registry.npmjs.org/process/-/process-0.11.1.tgz"
+                      "resolved": "https://registry.npmjs.org/process/-/process-0.11.2.tgz"
                     },
                     "xtend": {
-                      "version": "4.0.0",
+                      "version": "4.0.1",
                       "from": "xtend@>=4.0.0 <5.0.0",
-                      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.0.tgz"
+                      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz"
                     }
                   }
                 },
@@ -601,19 +1108,19 @@
                   }
                 },
                 "module-deps": {
-                  "version": "3.8.1",
+                  "version": "3.9.1",
                   "from": "module-deps@>=3.5.0 <4.0.0",
-                  "resolved": "https://registry.npmjs.org/module-deps/-/module-deps-3.8.1.tgz",
+                  "resolved": "https://registry.npmjs.org/module-deps/-/module-deps-3.9.1.tgz",
                   "dependencies": {
                     "JSONStream": {
-                      "version": "1.0.4",
+                      "version": "1.0.7",
                       "from": "JSONStream@>=1.0.3 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-1.0.4.tgz",
+                      "resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-1.0.7.tgz",
                       "dependencies": {
                         "jsonparse": {
-                          "version": "1.0.0",
-                          "from": "jsonparse@>=1.0.0 <1.1.0",
-                          "resolved": "https://registry.npmjs.org/jsonparse/-/jsonparse-1.0.0.tgz"
+                          "version": "1.2.0",
+                          "from": "jsonparse@>=1.1.0 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/jsonparse/-/jsonparse-1.2.0.tgz"
                         },
                         "through": {
                           "version": "2.3.8",
@@ -628,85 +1135,14 @@
                       "resolved": "https://registry.npmjs.org/defined/-/defined-1.0.0.tgz"
                     },
                     "detective": {
-                      "version": "4.1.1",
+                      "version": "4.3.1",
                       "from": "detective@>=4.0.0 <5.0.0",
-                      "resolved": "https://registry.npmjs.org/detective/-/detective-4.1.1.tgz",
+                      "resolved": "https://registry.npmjs.org/detective/-/detective-4.3.1.tgz",
                       "dependencies": {
                         "acorn": {
                           "version": "1.2.2",
                           "from": "acorn@>=1.0.3 <2.0.0",
                           "resolved": "https://registry.npmjs.org/acorn/-/acorn-1.2.2.tgz"
-                        },
-                        "escodegen": {
-                          "version": "1.6.1",
-                          "from": "escodegen@>=1.4.1 <2.0.0",
-                          "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.6.1.tgz",
-                          "dependencies": {
-                            "estraverse": {
-                              "version": "1.9.3",
-                              "from": "estraverse@>=1.9.1 <2.0.0",
-                              "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-1.9.3.tgz"
-                            },
-                            "esutils": {
-                              "version": "1.1.6",
-                              "from": "esutils@>=1.1.6 <2.0.0",
-                              "resolved": "https://registry.npmjs.org/esutils/-/esutils-1.1.6.tgz"
-                            },
-                            "esprima": {
-                              "version": "1.2.5",
-                              "from": "esprima@>=1.2.2 <2.0.0",
-                              "resolved": "https://registry.npmjs.org/esprima/-/esprima-1.2.5.tgz"
-                            },
-                            "optionator": {
-                              "version": "0.5.0",
-                              "from": "optionator@>=0.5.0 <0.6.0",
-                              "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.5.0.tgz",
-                              "dependencies": {
-                                "prelude-ls": {
-                                  "version": "1.1.2",
-                                  "from": "prelude-ls@>=1.1.1 <1.2.0",
-                                  "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz"
-                                },
-                                "deep-is": {
-                                  "version": "0.1.3",
-                                  "from": "deep-is@>=0.1.2 <0.2.0",
-                                  "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz"
-                                },
-                                "wordwrap": {
-                                  "version": "0.0.3",
-                                  "from": "wordwrap@>=0.0.2 <0.1.0",
-                                  "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz"
-                                },
-                                "type-check": {
-                                  "version": "0.3.1",
-                                  "from": "type-check@>=0.3.1 <0.4.0",
-                                  "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.1.tgz"
-                                },
-                                "levn": {
-                                  "version": "0.2.5",
-                                  "from": "levn@>=0.2.5 <0.3.0",
-                                  "resolved": "https://registry.npmjs.org/levn/-/levn-0.2.5.tgz"
-                                },
-                                "fast-levenshtein": {
-                                  "version": "1.0.6",
-                                  "from": "fast-levenshtein@>=1.0.0 <1.1.0",
-                                  "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-1.0.6.tgz"
-                                }
-                              }
-                            },
-                            "source-map": {
-                              "version": "0.1.43",
-                              "from": "source-map@>=0.1.40 <0.2.0",
-                              "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.43.tgz",
-                              "dependencies": {
-                                "amdefine": {
-                                  "version": "0.1.1",
-                                  "from": "amdefine@>=0.0.4",
-                                  "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-0.1.1.tgz"
-                                }
-                              }
-                            }
-                          }
                         }
                       }
                     },
@@ -743,9 +1179,9 @@
                               "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
                               "dependencies": {
                                 "core-util-is": {
-                                  "version": "1.0.1",
+                                  "version": "1.0.2",
                                   "from": "core-util-is@>=1.0.0 <1.1.0",
-                                  "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
+                                  "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
                                 },
                                 "string_decoder": {
                                   "version": "0.10.31",
@@ -769,16 +1205,16 @@
                       "resolved": "https://registry.npmjs.org/subarg/-/subarg-1.0.0.tgz",
                       "dependencies": {
                         "minimist": {
-                          "version": "1.1.1",
+                          "version": "1.2.0",
                           "from": "minimist@>=1.1.0 <2.0.0",
-                          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.1.1.tgz"
+                          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz"
                         }
                       }
                     },
                     "xtend": {
-                      "version": "4.0.0",
+                      "version": "4.0.1",
                       "from": "xtend@>=4.0.0 <5.0.0",
-                      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.0.tgz"
+                      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz"
                     }
                   }
                 },
@@ -821,13 +1257,13 @@
                 },
                 "readable-stream": {
                   "version": "1.1.13",
-                  "from": "readable-stream@>=1.1.0 <1.2.0",
+                  "from": "readable-stream@>=1.0.27-1 <2.0.0",
                   "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz",
                   "dependencies": {
                     "core-util-is": {
-                      "version": "1.0.1",
+                      "version": "1.0.2",
                       "from": "core-util-is@>=1.0.0 <1.1.0",
-                      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
+                      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
                     },
                     "string_decoder": {
                       "version": "0.10.31",
@@ -847,9 +1283,9 @@
                   "resolved": "https://registry.npmjs.org/shallow-copy/-/shallow-copy-0.0.1.tgz"
                 },
                 "shasum": {
-                  "version": "1.0.1",
+                  "version": "1.0.2",
                   "from": "shasum@>=1.0.0 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/shasum/-/shasum-1.0.1.tgz",
+                  "resolved": "https://registry.npmjs.org/shasum/-/shasum-1.0.2.tgz",
                   "dependencies": {
                     "json-stable-stringify": {
                       "version": "0.0.1",
@@ -864,9 +1300,9 @@
                       }
                     },
                     "sha.js": {
-                      "version": "2.3.6",
-                      "from": "sha.js@>=2.3.0 <2.4.0",
-                      "resolved": "https://registry.npmjs.org/sha.js/-/sha.js-2.3.6.tgz"
+                      "version": "2.4.4",
+                      "from": "sha.js@>=2.4.4 <2.5.0",
+                      "resolved": "https://registry.npmjs.org/sha.js/-/sha.js-2.4.4.tgz"
                     }
                   }
                 },
@@ -927,21 +1363,21 @@
                   "resolved": "https://registry.npmjs.org/through2/-/through2-1.1.1.tgz",
                   "dependencies": {
                     "xtend": {
-                      "version": "4.0.0",
+                      "version": "4.0.1",
                       "from": "xtend@>=4.0.0 <4.1.0-0",
-                      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.0.tgz"
+                      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz"
                     }
                   }
                 },
                 "timers-browserify": {
-                  "version": "1.4.1",
+                  "version": "1.4.2",
                   "from": "timers-browserify@>=1.0.1 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/timers-browserify/-/timers-browserify-1.4.1.tgz",
+                  "resolved": "https://registry.npmjs.org/timers-browserify/-/timers-browserify-1.4.2.tgz",
                   "dependencies": {
                     "process": {
-                      "version": "0.11.1",
+                      "version": "0.11.2",
                       "from": "process@>=0.11.0 <0.12.0",
-                      "resolved": "https://registry.npmjs.org/process/-/process-0.11.1.tgz"
+                      "resolved": "https://registry.npmjs.org/process/-/process-0.11.2.tgz"
                     }
                   }
                 },
@@ -984,13 +1420,13 @@
                           "dependencies": {
                             "source-map": {
                               "version": "0.1.43",
-                              "from": "source-map@>=0.1.40 <0.2.0",
+                              "from": "source-map@>=0.1.7 <0.2.0",
                               "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.43.tgz",
                               "dependencies": {
                                 "amdefine": {
-                                  "version": "0.1.1",
+                                  "version": "1.0.0",
                                   "from": "amdefine@>=0.0.4",
-                                  "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-0.1.1.tgz"
+                                  "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.0.tgz"
                                 }
                               }
                             },
@@ -1012,7 +1448,7 @@
                     },
                     "through": {
                       "version": "2.3.8",
-                      "from": "through@>=2.3.4 <2.4.0",
+                      "from": "through@>=2.2.7 <3.0.0",
                       "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz"
                     }
                   }
@@ -1120,9 +1556,9 @@
                   "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.34.tgz",
                   "dependencies": {
                     "amdefine": {
-                      "version": "0.1.1",
+                      "version": "1.0.0",
                       "from": "amdefine@>=0.0.4",
-                      "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-0.1.1.tgz"
+                      "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.0.tgz"
                     }
                   }
                 },
@@ -1144,11 +1580,6 @@
                   "resolved": "https://registry.npmjs.org/uglify-to-browserify/-/uglify-to-browserify-1.0.2.tgz"
                 }
               }
-            },
-            "bigint": {
-              "version": "0.4.2",
-              "from": "bigint@0.4.2",
-              "resolved": "https://registry.npmjs.org/bigint/-/bigint-0.4.2.tgz"
             }
           }
         },
@@ -1174,7 +1605,7 @@
           "dependencies": {
             "wordwrap": {
               "version": "0.0.3",
-              "from": "wordwrap@>=0.0.2 <0.1.0",
+              "from": "wordwrap@>=0.0.1 <0.1.0",
               "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz"
             },
             "minimist": {
@@ -1473,9 +1904,9 @@
                   "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz",
                   "dependencies": {
                     "core-util-is": {
-                      "version": "1.0.1",
+                      "version": "1.0.2",
                       "from": "core-util-is@>=1.0.0 <1.1.0",
-                      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
+                      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
                     },
                     "isarray": {
                       "version": "0.0.1",
@@ -1662,6 +2093,261 @@
         }
       }
     },
+    "jshint": {
+      "version": "2.5.1",
+      "from": "jshint@2.5.1",
+      "resolved": "https://registry.npmjs.org/jshint/-/jshint-2.5.1.tgz",
+      "dependencies": {
+        "shelljs": {
+          "version": "0.3.0",
+          "from": "shelljs@>=0.3.0 <0.4.0",
+          "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.3.0.tgz"
+        },
+        "underscore": {
+          "version": "1.6.0",
+          "from": "underscore@>=1.6.0 <1.7.0",
+          "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.6.0.tgz"
+        },
+        "cli": {
+          "version": "0.6.6",
+          "from": "cli@>=0.6.0 <0.7.0",
+          "resolved": "https://registry.npmjs.org/cli/-/cli-0.6.6.tgz",
+          "dependencies": {
+            "glob": {
+              "version": "3.2.11",
+              "from": "glob@>=3.2.1 <3.3.0",
+              "resolved": "https://registry.npmjs.org/glob/-/glob-3.2.11.tgz",
+              "dependencies": {
+                "inherits": {
+                  "version": "2.0.1",
+                  "from": "inherits@>=2.0.0 <3.0.0",
+                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                },
+                "minimatch": {
+                  "version": "0.3.0",
+                  "from": "minimatch@>=0.3.0 <0.4.0",
+                  "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.3.0.tgz",
+                  "dependencies": {
+                    "lru-cache": {
+                      "version": "2.7.3",
+                      "from": "lru-cache@>=2.0.0 <3.0.0",
+                      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.7.3.tgz"
+                    },
+                    "sigmund": {
+                      "version": "1.0.1",
+                      "from": "sigmund@>=1.0.0 <1.1.0",
+                      "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "minimatch": {
+          "version": "0.4.0",
+          "from": "minimatch@>=0.0.0 <1.0.0",
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.4.0.tgz",
+          "dependencies": {
+            "lru-cache": {
+              "version": "2.7.3",
+              "from": "lru-cache@>=2.0.0 <3.0.0",
+              "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.7.3.tgz"
+            },
+            "sigmund": {
+              "version": "1.0.1",
+              "from": "sigmund@>=1.0.0 <1.1.0",
+              "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz"
+            }
+          }
+        },
+        "htmlparser2": {
+          "version": "3.7.3",
+          "from": "htmlparser2@>=3.7.0 <3.8.0",
+          "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-3.7.3.tgz",
+          "dependencies": {
+            "domhandler": {
+              "version": "2.2.1",
+              "from": "domhandler@>=2.2.0 <2.3.0",
+              "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-2.2.1.tgz"
+            },
+            "domutils": {
+              "version": "1.5.1",
+              "from": "domutils@>=1.5.0 <1.6.0",
+              "resolved": "https://registry.npmjs.org/domutils/-/domutils-1.5.1.tgz",
+              "dependencies": {
+                "dom-serializer": {
+                  "version": "0.1.0",
+                  "from": "dom-serializer@>=0.0.0 <1.0.0",
+                  "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-0.1.0.tgz",
+                  "dependencies": {
+                    "domelementtype": {
+                      "version": "1.1.3",
+                      "from": "domelementtype@>=1.1.1 <1.2.0",
+                      "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.1.3.tgz"
+                    },
+                    "entities": {
+                      "version": "1.1.1",
+                      "from": "entities@>=1.1.1 <1.2.0",
+                      "resolved": "https://registry.npmjs.org/entities/-/entities-1.1.1.tgz"
+                    }
+                  }
+                }
+              }
+            },
+            "domelementtype": {
+              "version": "1.3.0",
+              "from": "domelementtype@>=1.0.0 <2.0.0",
+              "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.3.0.tgz"
+            },
+            "readable-stream": {
+              "version": "1.1.13",
+              "from": "readable-stream@>=1.1.0 <1.2.0",
+              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz",
+              "dependencies": {
+                "core-util-is": {
+                  "version": "1.0.2",
+                  "from": "core-util-is@>=1.0.0 <1.1.0",
+                  "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
+                },
+                "isarray": {
+                  "version": "0.0.1",
+                  "from": "isarray@0.0.1",
+                  "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                },
+                "string_decoder": {
+                  "version": "0.10.31",
+                  "from": "string_decoder@>=0.10.0 <0.11.0",
+                  "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+                },
+                "inherits": {
+                  "version": "2.0.1",
+                  "from": "inherits@>=2.0.1 <2.1.0",
+                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                }
+              }
+            },
+            "entities": {
+              "version": "1.0.0",
+              "from": "entities@>=1.0.0 <1.1.0",
+              "resolved": "https://registry.npmjs.org/entities/-/entities-1.0.0.tgz"
+            }
+          }
+        },
+        "console-browserify": {
+          "version": "1.1.0",
+          "from": "console-browserify@>=1.1.0 <1.2.0",
+          "resolved": "https://registry.npmjs.org/console-browserify/-/console-browserify-1.1.0.tgz",
+          "dependencies": {
+            "date-now": {
+              "version": "0.1.4",
+              "from": "date-now@>=0.1.4 <0.2.0",
+              "resolved": "https://registry.npmjs.org/date-now/-/date-now-0.1.4.tgz"
+            }
+          }
+        },
+        "exit": {
+          "version": "0.1.2",
+          "from": "exit@>=0.1.0 <0.2.0",
+          "resolved": "https://registry.npmjs.org/exit/-/exit-0.1.2.tgz"
+        },
+        "strip-json-comments": {
+          "version": "0.1.3",
+          "from": "strip-json-comments@>=0.1.0 <0.2.0",
+          "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-0.1.3.tgz"
+        }
+      }
+    },
+    "mocha": {
+      "version": "1.20.0",
+      "from": "mocha@1.20.0",
+      "resolved": "https://registry.npmjs.org/mocha/-/mocha-1.20.0.tgz",
+      "dependencies": {
+        "commander": {
+          "version": "2.0.0",
+          "from": "commander@2.0.0",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-2.0.0.tgz"
+        },
+        "growl": {
+          "version": "1.7.0",
+          "from": "growl@>=1.7.0 <1.8.0",
+          "resolved": "https://registry.npmjs.org/growl/-/growl-1.7.0.tgz"
+        },
+        "jade": {
+          "version": "0.26.3",
+          "from": "jade@0.26.3",
+          "resolved": "https://registry.npmjs.org/jade/-/jade-0.26.3.tgz",
+          "dependencies": {
+            "commander": {
+              "version": "0.6.1",
+              "from": "commander@0.6.1",
+              "resolved": "https://registry.npmjs.org/commander/-/commander-0.6.1.tgz"
+            },
+            "mkdirp": {
+              "version": "0.3.0",
+              "from": "mkdirp@0.3.0",
+              "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.3.0.tgz"
+            }
+          }
+        },
+        "diff": {
+          "version": "1.0.7",
+          "from": "diff@1.0.7",
+          "resolved": "https://registry.npmjs.org/diff/-/diff-1.0.7.tgz"
+        },
+        "debug": {
+          "version": "2.2.0",
+          "from": "debug@*",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
+          "dependencies": {
+            "ms": {
+              "version": "0.7.1",
+              "from": "ms@0.7.1",
+              "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz"
+            }
+          }
+        },
+        "mkdirp": {
+          "version": "0.3.5",
+          "from": "mkdirp@0.3.5",
+          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.3.5.tgz"
+        },
+        "glob": {
+          "version": "3.2.3",
+          "from": "glob@3.2.3",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-3.2.3.tgz",
+          "dependencies": {
+            "minimatch": {
+              "version": "0.2.14",
+              "from": "minimatch@>=0.2.11 <0.3.0",
+              "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.2.14.tgz",
+              "dependencies": {
+                "lru-cache": {
+                  "version": "2.7.3",
+                  "from": "lru-cache@>=2.0.0 <3.0.0",
+                  "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.7.3.tgz"
+                },
+                "sigmund": {
+                  "version": "1.0.1",
+                  "from": "sigmund@>=1.0.0 <1.1.0",
+                  "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz"
+                }
+              }
+            },
+            "graceful-fs": {
+              "version": "2.0.3",
+              "from": "graceful-fs@>=2.0.0 <3.0.0",
+              "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-2.0.3.tgz"
+            },
+            "inherits": {
+              "version": "2.0.1",
+              "from": "inherits@>=2.0.0 <3.0.0",
+              "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+            }
+          }
+        }
+      }
+    },
     "optimist": {
       "version": "0.6.1",
       "from": "optimist@0.6.1",
@@ -1679,15 +2365,164 @@
         }
       }
     },
+    "request": {
+      "version": "2.36.0",
+      "from": "request@2.36.0",
+      "resolved": "https://registry.npmjs.org/request/-/request-2.36.0.tgz",
+      "dependencies": {
+        "qs": {
+          "version": "0.6.6",
+          "from": "qs@>=0.6.0 <0.7.0",
+          "resolved": "https://registry.npmjs.org/qs/-/qs-0.6.6.tgz"
+        },
+        "json-stringify-safe": {
+          "version": "5.0.1",
+          "from": "json-stringify-safe@>=5.0.0 <5.1.0",
+          "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz"
+        },
+        "mime": {
+          "version": "1.2.11",
+          "from": "mime@>=1.2.9 <1.3.0",
+          "resolved": "https://registry.npmjs.org/mime/-/mime-1.2.11.tgz"
+        },
+        "forever-agent": {
+          "version": "0.5.2",
+          "from": "forever-agent@>=0.5.0 <0.6.0",
+          "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.5.2.tgz"
+        },
+        "node-uuid": {
+          "version": "1.4.7",
+          "from": "node-uuid@>=1.4.0 <1.5.0",
+          "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.7.tgz"
+        },
+        "tough-cookie": {
+          "version": "2.2.1",
+          "from": "tough-cookie@>=0.12.0",
+          "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.2.1.tgz"
+        },
+        "form-data": {
+          "version": "0.1.4",
+          "from": "form-data@>=0.1.0 <0.2.0",
+          "resolved": "https://registry.npmjs.org/form-data/-/form-data-0.1.4.tgz",
+          "dependencies": {
+            "combined-stream": {
+              "version": "0.0.7",
+              "from": "combined-stream@>=0.0.4 <0.1.0",
+              "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-0.0.7.tgz",
+              "dependencies": {
+                "delayed-stream": {
+                  "version": "0.0.5",
+                  "from": "delayed-stream@0.0.5",
+                  "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-0.0.5.tgz"
+                }
+              }
+            }
+          }
+        },
+        "tunnel-agent": {
+          "version": "0.4.2",
+          "from": "tunnel-agent@>=0.4.0 <0.5.0",
+          "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.2.tgz"
+        },
+        "http-signature": {
+          "version": "0.10.1",
+          "from": "http-signature@>=0.10.0 <0.11.0",
+          "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-0.10.1.tgz",
+          "dependencies": {
+            "assert-plus": {
+              "version": "0.1.5",
+              "from": "assert-plus@>=0.1.5 <0.2.0",
+              "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.1.5.tgz"
+            },
+            "asn1": {
+              "version": "0.1.11",
+              "from": "asn1@0.1.11",
+              "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.1.11.tgz"
+            },
+            "ctype": {
+              "version": "0.5.3",
+              "from": "ctype@0.5.3",
+              "resolved": "https://registry.npmjs.org/ctype/-/ctype-0.5.3.tgz"
+            }
+          }
+        },
+        "oauth-sign": {
+          "version": "0.3.0",
+          "from": "oauth-sign@>=0.3.0 <0.4.0",
+          "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.3.0.tgz"
+        },
+        "hawk": {
+          "version": "1.0.0",
+          "from": "hawk@>=1.0.0 <1.1.0",
+          "resolved": "https://registry.npmjs.org/hawk/-/hawk-1.0.0.tgz",
+          "dependencies": {
+            "hoek": {
+              "version": "0.9.1",
+              "from": "hoek@>=0.9.0 <0.10.0",
+              "resolved": "https://registry.npmjs.org/hoek/-/hoek-0.9.1.tgz"
+            },
+            "boom": {
+              "version": "0.4.2",
+              "from": "boom@>=0.4.0 <0.5.0",
+              "resolved": "https://registry.npmjs.org/boom/-/boom-0.4.2.tgz"
+            },
+            "cryptiles": {
+              "version": "0.2.2",
+              "from": "cryptiles@>=0.2.0 <0.3.0",
+              "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-0.2.2.tgz"
+            },
+            "sntp": {
+              "version": "0.2.4",
+              "from": "sntp@>=0.2.0 <0.3.0",
+              "resolved": "https://registry.npmjs.org/sntp/-/sntp-0.2.4.tgz"
+            }
+          }
+        },
+        "aws-sign2": {
+          "version": "0.5.0",
+          "from": "aws-sign2@>=0.5.0 <0.6.0",
+          "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.5.0.tgz"
+        }
+      }
+    },
+    "should": {
+      "version": "4.0.0",
+      "from": "should@4.0.0",
+      "resolved": "https://registry.npmjs.org/should/-/should-4.0.0.tgz"
+    },
+    "temp": {
+      "version": "0.7.0",
+      "from": "temp@0.7.0",
+      "resolved": "https://registry.npmjs.org/temp/-/temp-0.7.0.tgz",
+      "dependencies": {
+        "rimraf": {
+          "version": "2.2.8",
+          "from": "rimraf@>=2.2.6 <2.3.0",
+          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.2.8.tgz"
+        }
+      }
+    },
     "toobusy-js": {
       "version": "0.4.2",
-      "from": "git://github.com/strml/node-toobusy.git#ed8b8bb6909a82ae3007940cd5ac42f0488b00ab",
+      "from": "strml/node-toobusy#ed8b8bb6909a82ae3007940cd5ac42f0488b00ab",
       "resolved": "git://github.com/strml/node-toobusy.git#ed8b8bb6909a82ae3007940cd5ac42f0488b00ab"
     },
     "underscore": {
       "version": "1.7.0",
       "from": "underscore@1.7.0",
       "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.7.0.tgz"
+    },
+    "walk": {
+      "version": "2.3.3",
+      "from": "walk@2.3.3",
+      "resolved": "https://registry.npmjs.org/walk/-/walk-2.3.3.tgz",
+      "dependencies": {
+        "foreachasync": {
+          "version": "3.0.0",
+          "from": "foreachasync@>=3.0.0 <4.0.0",
+          "resolved": "https://registry.npmjs.org/foreachasync/-/foreachasync-3.0.0.tgz"
+        }
+      }
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "underscore": "1.7.0"
   },
   "devDependencies": {
-    "ass": "0.0.4",
+    "ass": "git://github.com/jrgm/ass.git#5be99ee7abc9fcf63f9ebcc37b151b9c822146d1",
     "awsbox": "0.7.0",
     "jshint": "2.5.1",
     "mocha": "1.20.0",


### PR DESCRIPTION
@vladikoff r?

This fixes the build issues you ran into over in https://github.com/mozilla/browserid-verifier/pull/70, but updating to the same version of ass used in fxa-auth-server.  Also `npm shrinkwrap --dev` to hopefully avoid issues in future.