### PR TITLE
fix(deps): Upgrade dependencies to silence NSP warnings

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -4,6 +4,8 @@
 
 const
 express = require('express'),
+bodyParser = require('body-parser'),
+morgan = require('morgan'),
 http = require('http'),
 toobusy = require('toobusy-js'),
 log = require('./log').getLogger('bid.server'),
@@ -63,7 +65,7 @@ app.use(function(req, res, next) {
 });
 
 // log HTTP requests
-app.use(express.logger({
+app.use(morgan('common', {
   stream: {
     write: function(message){
       // trim newlines as our logger inserts them for us.
@@ -88,15 +90,15 @@ app.use(function(req, res, next) {
 // log summary - GH24
 app.use(summary());
 
-app.use(express.json({ limit: "10kb" }));
-app.use(express.urlencoded({ limit: "10kb" }));
+app.use(bodyParser.json({ limit: "10kb" }));
+app.use(bodyParser.urlencoded({ limit: "10kb" }));
 
 app.post('/verify', v1api.bind(v1api, verifier));
 app.post('/', v1api.bind(v1api, verifier));
 app.post('/v2', v2api.bind(v2api, verifier));
 
 function wrongMethod(req, res) {
-  return res.send(405);
+  return res.sendStatus(405);
 }
 
 ['/verify', '/', '/v2'].forEach(function(route) {

--- a/lib/v1.js
+++ b/lib/v1.js
@@ -26,8 +26,9 @@ function verify(verifier, req, res) {
     // why couldn't we extract these guys?  Is it because the request parameters weren't encoded as we expect? GH-643
     const want_ct = [ 'application/x-www-form-urlencoded', 'application/json' ];
     var reason;
+    var ct = 'none';
     try {
-      var ct = req.headers['content-type'] || 'none';
+      ct = req.headers['content-type'] || ct;
       if (ct.indexOf(';') !== -1) {
         ct = ct.substr(0, ct.indexOf(';'));
       }

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -7,6 +7,11 @@
       "from": "git://github.com/jrgm/ass.git#5be99ee7abc9fcf63f9ebcc37b151b9c822146d1",
       "resolved": "git://github.com/jrgm/ass.git#5be99ee7abc9fcf63f9ebcc37b151b9c822146d1",
       "dependencies": {
+        "async": {
+          "version": "0.9.0",
+          "from": "async@0.9.0",
+          "resolved": "https://registry.npmjs.org/async/-/async-0.9.0.tgz"
+        },
         "blanket": {
           "version": "1.1.6",
           "from": "blanket@1.1.6",
@@ -81,9 +86,9 @@
                   "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.3.0.tgz"
                 },
                 "readable-stream": {
-                  "version": "1.1.13",
+                  "version": "1.1.14",
                   "from": "readable-stream@>=1.1.0 <1.2.0",
-                  "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz",
+                  "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
                   "dependencies": {
                     "core-util-is": {
                       "version": "1.0.2",
@@ -101,9 +106,9 @@
                       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
                     },
                     "inherits": {
-                      "version": "2.0.1",
+                      "version": "2.0.3",
                       "from": "inherits@>=2.0.1 <2.1.0",
-                      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz"
                     }
                   }
                 }
@@ -160,132 +165,211 @@
       }
     },
     "async": {
-      "version": "0.9.0",
-      "from": "async@0.9.0",
-      "resolved": "https://registry.npmjs.org/async/-/async-0.9.0.tgz"
+      "version": "2.0.1",
+      "from": "async@2.0.1",
+      "resolved": "https://registry.npmjs.org/async/-/async-2.0.1.tgz",
+      "dependencies": {
+        "lodash": {
+          "version": "4.16.4",
+          "from": "lodash@>=4.8.0 <5.0.0",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.16.4.tgz"
+        }
+      }
+    },
+    "body-parser": {
+      "version": "1.15.2",
+      "from": "body-parser@1.15.2",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.15.2.tgz",
+      "dependencies": {
+        "bytes": {
+          "version": "2.4.0",
+          "from": "bytes@2.4.0",
+          "resolved": "https://registry.npmjs.org/bytes/-/bytes-2.4.0.tgz"
+        },
+        "content-type": {
+          "version": "1.0.2",
+          "from": "content-type@>=1.0.2 <1.1.0",
+          "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.2.tgz"
+        },
+        "debug": {
+          "version": "2.2.0",
+          "from": "debug@>=2.2.0 <2.3.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
+          "dependencies": {
+            "ms": {
+              "version": "0.7.1",
+              "from": "ms@0.7.1",
+              "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz"
+            }
+          }
+        },
+        "depd": {
+          "version": "1.1.0",
+          "from": "depd@>=1.1.0 <1.2.0",
+          "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.0.tgz"
+        },
+        "http-errors": {
+          "version": "1.5.0",
+          "from": "http-errors@>=1.5.0 <1.6.0",
+          "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.5.0.tgz",
+          "dependencies": {
+            "inherits": {
+              "version": "2.0.1",
+              "from": "inherits@2.0.1",
+              "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+            },
+            "setprototypeof": {
+              "version": "1.0.1",
+              "from": "setprototypeof@1.0.1",
+              "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.0.1.tgz"
+            },
+            "statuses": {
+              "version": "1.3.0",
+              "from": "statuses@>=1.3.0 <2.0.0",
+              "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.3.0.tgz"
+            }
+          }
+        },
+        "iconv-lite": {
+          "version": "0.4.13",
+          "from": "iconv-lite@0.4.13",
+          "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.13.tgz"
+        },
+        "on-finished": {
+          "version": "2.3.0",
+          "from": "on-finished@>=2.3.0 <2.4.0",
+          "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.3.0.tgz",
+          "dependencies": {
+            "ee-first": {
+              "version": "1.1.1",
+              "from": "ee-first@1.1.1",
+              "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz"
+            }
+          }
+        },
+        "qs": {
+          "version": "6.2.0",
+          "from": "qs@6.2.0",
+          "resolved": "https://registry.npmjs.org/qs/-/qs-6.2.0.tgz"
+        },
+        "raw-body": {
+          "version": "2.1.7",
+          "from": "raw-body@>=2.1.7 <2.2.0",
+          "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.1.7.tgz",
+          "dependencies": {
+            "unpipe": {
+              "version": "1.0.0",
+              "from": "unpipe@1.0.0",
+              "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz"
+            }
+          }
+        },
+        "type-is": {
+          "version": "1.6.13",
+          "from": "type-is@>=1.6.13 <1.7.0",
+          "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.13.tgz",
+          "dependencies": {
+            "media-typer": {
+              "version": "0.3.0",
+              "from": "media-typer@0.3.0",
+              "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz"
+            },
+            "mime-types": {
+              "version": "2.1.12",
+              "from": "mime-types@>=2.1.7 <2.2.0",
+              "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.12.tgz",
+              "dependencies": {
+                "mime-db": {
+                  "version": "1.24.0",
+                  "from": "mime-db@>=1.24.0 <1.25.0",
+                  "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.24.0.tgz"
+                }
+              }
+            }
+          }
+        }
+      }
     },
     "browserid-local-verify": {
-      "version": "0.4.0",
-      "from": "browserid-local-verify@0.4.0",
-      "resolved": "https://registry.npmjs.org/browserid-local-verify/-/browserid-local-verify-0.4.0.tgz",
+      "version": "0.5.0",
+      "from": "browserid-local-verify@0.5.0",
+      "resolved": "https://registry.npmjs.org/browserid-local-verify/-/browserid-local-verify-0.5.0.tgz",
       "dependencies": {
         "browserid-crypto": {
-          "version": "0.8.0",
-          "from": "browserid-crypto@0.8.0",
-          "resolved": "https://registry.npmjs.org/browserid-crypto/-/browserid-crypto-0.8.0.tgz",
+          "version": "0.9.0",
+          "from": "browserid-crypto@0.9.0",
+          "resolved": "https://registry.npmjs.org/browserid-crypto/-/browserid-crypto-0.9.0.tgz",
           "dependencies": {
             "browserify": {
-              "version": "5.9.1",
-              "from": "browserify@5.9.1",
-              "resolved": "https://registry.npmjs.org/browserify/-/browserify-5.9.1.tgz",
+              "version": "13.1.0",
+              "from": "browserify@13.1.0",
+              "resolved": "https://registry.npmjs.org/browserify/-/browserify-13.1.0.tgz",
               "dependencies": {
                 "JSONStream": {
-                  "version": "0.8.4",
-                  "from": "JSONStream@>=0.8.3 <0.9.0",
-                  "resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-0.8.4.tgz",
+                  "version": "1.2.1",
+                  "from": "JSONStream@>=1.0.3 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-1.2.1.tgz",
                   "dependencies": {
                     "jsonparse": {
-                      "version": "0.0.5",
-                      "from": "jsonparse@0.0.5",
-                      "resolved": "https://registry.npmjs.org/jsonparse/-/jsonparse-0.0.5.tgz"
+                      "version": "1.2.0",
+                      "from": "jsonparse@>=1.2.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/jsonparse/-/jsonparse-1.2.0.tgz"
                     },
                     "through": {
                       "version": "2.3.8",
-                      "from": "through@>=2.3.4 <2.4.0",
+                      "from": "through@>=2.2.7 <3.0.0",
                       "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz"
                     }
                   }
                 },
                 "assert": {
-                  "version": "1.1.2",
-                  "from": "assert@>=1.1.0 <1.2.0",
-                  "resolved": "https://registry.npmjs.org/assert/-/assert-1.1.2.tgz"
+                  "version": "1.3.0",
+                  "from": "assert@>=1.3.0 <1.4.0",
+                  "resolved": "https://registry.npmjs.org/assert/-/assert-1.3.0.tgz"
                 },
                 "browser-pack": {
-                  "version": "3.2.0",
-                  "from": "browser-pack@>=3.0.0 <4.0.0",
-                  "resolved": "https://registry.npmjs.org/browser-pack/-/browser-pack-3.2.0.tgz",
+                  "version": "6.0.1",
+                  "from": "browser-pack@>=6.0.1 <7.0.0",
+                  "resolved": "https://registry.npmjs.org/browser-pack/-/browser-pack-6.0.1.tgz",
                   "dependencies": {
                     "combine-source-map": {
-                      "version": "0.3.0",
-                      "from": "combine-source-map@>=0.3.0 <0.4.0",
-                      "resolved": "https://registry.npmjs.org/combine-source-map/-/combine-source-map-0.3.0.tgz",
+                      "version": "0.7.2",
+                      "from": "combine-source-map@>=0.7.1 <0.8.0",
+                      "resolved": "https://registry.npmjs.org/combine-source-map/-/combine-source-map-0.7.2.tgz",
                       "dependencies": {
-                        "inline-source-map": {
-                          "version": "0.3.1",
-                          "from": "inline-source-map@>=0.3.0 <0.4.0",
-                          "resolved": "https://registry.npmjs.org/inline-source-map/-/inline-source-map-0.3.1.tgz",
-                          "dependencies": {
-                            "source-map": {
-                              "version": "0.3.0",
-                              "from": "source-map@>=0.3.0 <0.4.0",
-                              "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.3.0.tgz",
-                              "dependencies": {
-                                "amdefine": {
-                                  "version": "1.0.0",
-                                  "from": "amdefine@>=0.0.4",
-                                  "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.0.tgz"
-                                }
-                              }
-                            }
-                          }
-                        },
                         "convert-source-map": {
-                          "version": "0.3.5",
-                          "from": "convert-source-map@>=0.3.0 <0.4.0",
-                          "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-0.3.5.tgz"
+                          "version": "1.1.3",
+                          "from": "convert-source-map@>=1.1.0 <1.2.0",
+                          "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.1.3.tgz"
+                        },
+                        "inline-source-map": {
+                          "version": "0.6.2",
+                          "from": "inline-source-map@>=0.6.0 <0.7.0",
+                          "resolved": "https://registry.npmjs.org/inline-source-map/-/inline-source-map-0.6.2.tgz"
+                        },
+                        "lodash.memoize": {
+                          "version": "3.0.4",
+                          "from": "lodash.memoize@>=3.0.3 <3.1.0",
+                          "resolved": "https://registry.npmjs.org/lodash.memoize/-/lodash.memoize-3.0.4.tgz"
                         },
                         "source-map": {
-                          "version": "0.1.43",
-                          "from": "source-map@>=0.1.7 <0.2.0",
-                          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.43.tgz",
-                          "dependencies": {
-                            "amdefine": {
-                              "version": "1.0.0",
-                              "from": "amdefine@>=0.0.4",
-                              "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.0.tgz"
-                            }
-                          }
+                          "version": "0.5.6",
+                          "from": "source-map@>=0.5.3 <0.6.0",
+                          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz"
                         }
                       }
                     },
-                    "through2": {
-                      "version": "0.5.1",
-                      "from": "through2@>=0.5.1 <0.6.0",
-                      "resolved": "https://registry.npmjs.org/through2/-/through2-0.5.1.tgz",
-                      "dependencies": {
-                        "readable-stream": {
-                          "version": "1.0.33",
-                          "from": "readable-stream@>=1.0.17 <1.1.0",
-                          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
-                          "dependencies": {
-                            "core-util-is": {
-                              "version": "1.0.2",
-                              "from": "core-util-is@>=1.0.0 <1.1.0",
-                              "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
-                            },
-                            "string_decoder": {
-                              "version": "0.10.31",
-                              "from": "string_decoder@>=0.10.0 <0.11.0",
-                              "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
-                            }
-                          }
-                        }
-                      }
+                    "umd": {
+                      "version": "3.0.1",
+                      "from": "umd@>=3.0.0 <4.0.0",
+                      "resolved": "https://registry.npmjs.org/umd/-/umd-3.0.1.tgz"
                     }
                   }
                 },
                 "browser-resolve": {
-                  "version": "1.11.1",
-                  "from": "browser-resolve@>=1.3.0 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/browser-resolve/-/browser-resolve-1.11.1.tgz",
-                  "dependencies": {
-                    "resolve": {
-                      "version": "1.1.7",
-                      "from": "resolve@1.1.7",
-                      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.1.7.tgz"
-                    }
-                  }
+                  "version": "1.11.2",
+                  "from": "browser-resolve@>=1.11.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/browser-resolve/-/browser-resolve-1.11.2.tgz"
                 },
                 "browserify-zlib": {
                   "version": "0.1.4",
@@ -293,53 +377,70 @@
                   "resolved": "https://registry.npmjs.org/browserify-zlib/-/browserify-zlib-0.1.4.tgz",
                   "dependencies": {
                     "pako": {
-                      "version": "0.2.8",
+                      "version": "0.2.9",
                       "from": "pako@>=0.2.0 <0.3.0",
-                      "resolved": "https://registry.npmjs.org/pako/-/pako-0.2.8.tgz"
+                      "resolved": "https://registry.npmjs.org/pako/-/pako-0.2.9.tgz"
                     }
                   }
                 },
                 "buffer": {
-                  "version": "2.8.2",
-                  "from": "buffer@>=2.3.0 <3.0.0",
-                  "resolved": "https://registry.npmjs.org/buffer/-/buffer-2.8.2.tgz",
+                  "version": "4.9.1",
+                  "from": "buffer@>=4.1.0 <5.0.0",
+                  "resolved": "https://registry.npmjs.org/buffer/-/buffer-4.9.1.tgz",
                   "dependencies": {
                     "base64-js": {
-                      "version": "0.0.7",
-                      "from": "base64-js@0.0.7",
-                      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-0.0.7.tgz"
+                      "version": "1.2.0",
+                      "from": "base64-js@>=1.0.2 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.2.0.tgz"
                     },
                     "ieee754": {
-                      "version": "1.1.6",
+                      "version": "1.1.8",
                       "from": "ieee754@>=1.1.4 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.6.tgz"
+                      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.8.tgz"
                     },
-                    "is-array": {
-                      "version": "1.0.1",
-                      "from": "is-array@>=1.0.1 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/is-array/-/is-array-1.0.1.tgz"
+                    "isarray": {
+                      "version": "1.0.0",
+                      "from": "isarray@>=1.0.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz"
                     }
                   }
                 },
-                "builtins": {
-                  "version": "0.0.7",
-                  "from": "builtins@>=0.0.3 <0.1.0",
-                  "resolved": "https://registry.npmjs.org/builtins/-/builtins-0.0.7.tgz"
-                },
-                "commondir": {
-                  "version": "0.0.1",
-                  "from": "commondir@0.0.1",
-                  "resolved": "https://registry.npmjs.org/commondir/-/commondir-0.0.1.tgz"
-                },
                 "concat-stream": {
-                  "version": "1.4.10",
-                  "from": "concat-stream@>=1.4.1 <1.5.0",
-                  "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.4.10.tgz",
+                  "version": "1.5.2",
+                  "from": "concat-stream@>=1.5.1 <1.6.0",
+                  "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.5.2.tgz",
                   "dependencies": {
                     "typedarray": {
                       "version": "0.0.6",
                       "from": "typedarray@>=0.0.5 <0.1.0",
                       "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz"
+                    },
+                    "readable-stream": {
+                      "version": "2.0.6",
+                      "from": "readable-stream@>=2.0.0 <2.1.0",
+                      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.6.tgz",
+                      "dependencies": {
+                        "core-util-is": {
+                          "version": "1.0.2",
+                          "from": "core-util-is@>=1.0.0 <1.1.0",
+                          "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
+                        },
+                        "isarray": {
+                          "version": "1.0.0",
+                          "from": "isarray@>=1.0.0 <1.1.0",
+                          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz"
+                        },
+                        "process-nextick-args": {
+                          "version": "1.0.7",
+                          "from": "process-nextick-args@>=1.0.6 <1.1.0",
+                          "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz"
+                        },
+                        "util-deprecate": {
+                          "version": "1.0.2",
+                          "from": "util-deprecate@>=1.0.1 <1.1.0",
+                          "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz"
+                        }
+                      }
                     }
                   }
                 },
@@ -356,9 +457,9 @@
                   }
                 },
                 "constants-browserify": {
-                  "version": "0.0.1",
-                  "from": "constants-browserify@>=0.0.1 <0.1.0",
-                  "resolved": "https://registry.npmjs.org/constants-browserify/-/constants-browserify-0.0.1.tgz"
+                  "version": "1.0.0",
+                  "from": "constants-browserify@>=1.0.0 <1.1.0",
+                  "resolved": "https://registry.npmjs.org/constants-browserify/-/constants-browserify-1.0.0.tgz"
                 },
                 "crypto-browserify": {
                   "version": "3.11.0",
@@ -381,9 +482,9 @@
                               "resolved": "https://registry.npmjs.org/buffer-xor/-/buffer-xor-1.0.3.tgz"
                             },
                             "cipher-base": {
-                              "version": "1.0.2",
+                              "version": "1.0.3",
                               "from": "cipher-base@>=1.0.0 <2.0.0",
-                              "resolved": "https://registry.npmjs.org/cipher-base/-/cipher-base-1.0.2.tgz"
+                              "resolved": "https://registry.npmjs.org/cipher-base/-/cipher-base-1.0.3.tgz"
                             }
                           }
                         },
@@ -393,9 +494,9 @@
                           "resolved": "https://registry.npmjs.org/browserify-des/-/browserify-des-1.0.0.tgz",
                           "dependencies": {
                             "cipher-base": {
-                              "version": "1.0.2",
+                              "version": "1.0.3",
                               "from": "cipher-base@>=1.0.1 <2.0.0",
-                              "resolved": "https://registry.npmjs.org/cipher-base/-/cipher-base-1.0.2.tgz"
+                              "resolved": "https://registry.npmjs.org/cipher-base/-/cipher-base-1.0.3.tgz"
                             },
                             "des.js": {
                               "version": "1.0.0",
@@ -424,9 +525,9 @@
                       "resolved": "https://registry.npmjs.org/browserify-sign/-/browserify-sign-4.0.0.tgz",
                       "dependencies": {
                         "bn.js": {
-                          "version": "4.10.5",
-                          "from": "bn.js@>=4.1.0 <5.0.0",
-                          "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.10.5.tgz"
+                          "version": "4.11.6",
+                          "from": "bn.js@>=4.1.1 <5.0.0",
+                          "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.6.tgz"
                         },
                         "browserify-rsa": {
                           "version": "4.0.1",
@@ -434,14 +535,14 @@
                           "resolved": "https://registry.npmjs.org/browserify-rsa/-/browserify-rsa-4.0.1.tgz"
                         },
                         "elliptic": {
-                          "version": "6.2.3",
+                          "version": "6.3.2",
                           "from": "elliptic@>=6.0.0 <7.0.0",
-                          "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.2.3.tgz",
+                          "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.3.2.tgz",
                           "dependencies": {
                             "brorand": {
-                              "version": "1.0.5",
+                              "version": "1.0.6",
                               "from": "brorand@>=1.0.1 <2.0.0",
-                              "resolved": "https://registry.npmjs.org/brorand/-/brorand-1.0.5.tgz"
+                              "resolved": "https://registry.npmjs.org/brorand/-/brorand-1.0.6.tgz"
                             },
                             "hash.js": {
                               "version": "1.0.3",
@@ -456,9 +557,9 @@
                           "resolved": "https://registry.npmjs.org/parse-asn1/-/parse-asn1-5.0.0.tgz",
                           "dependencies": {
                             "asn1.js": {
-                              "version": "4.5.1",
+                              "version": "4.8.1",
                               "from": "asn1.js@>=4.0.0 <5.0.0",
-                              "resolved": "https://registry.npmjs.org/asn1.js/-/asn1.js-4.5.1.tgz",
+                              "resolved": "https://registry.npmjs.org/asn1.js/-/asn1.js-4.8.1.tgz",
                               "dependencies": {
                                 "minimalistic-assert": {
                                   "version": "1.0.0",
@@ -478,9 +579,9 @@
                                   "resolved": "https://registry.npmjs.org/buffer-xor/-/buffer-xor-1.0.3.tgz"
                                 },
                                 "cipher-base": {
-                                  "version": "1.0.2",
+                                  "version": "1.0.3",
                                   "from": "cipher-base@>=1.0.0 <2.0.0",
-                                  "resolved": "https://registry.npmjs.org/cipher-base/-/cipher-base-1.0.2.tgz"
+                                  "resolved": "https://registry.npmjs.org/cipher-base/-/cipher-base-1.0.3.tgz"
                                 }
                               }
                             },
@@ -499,19 +600,19 @@
                       "resolved": "https://registry.npmjs.org/create-ecdh/-/create-ecdh-4.0.0.tgz",
                       "dependencies": {
                         "bn.js": {
-                          "version": "4.10.5",
+                          "version": "4.11.6",
                           "from": "bn.js@>=4.1.0 <5.0.0",
-                          "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.10.5.tgz"
+                          "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.6.tgz"
                         },
                         "elliptic": {
-                          "version": "6.2.3",
+                          "version": "6.3.2",
                           "from": "elliptic@>=6.0.0 <7.0.0",
-                          "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.2.3.tgz",
+                          "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.3.2.tgz",
                           "dependencies": {
                             "brorand": {
-                              "version": "1.0.5",
+                              "version": "1.0.6",
                               "from": "brorand@>=1.0.1 <2.0.0",
-                              "resolved": "https://registry.npmjs.org/brorand/-/brorand-1.0.5.tgz"
+                              "resolved": "https://registry.npmjs.org/brorand/-/brorand-1.0.6.tgz"
                             },
                             "hash.js": {
                               "version": "1.0.3",
@@ -528,9 +629,9 @@
                       "resolved": "https://registry.npmjs.org/create-hash/-/create-hash-1.1.2.tgz",
                       "dependencies": {
                         "cipher-base": {
-                          "version": "1.0.2",
+                          "version": "1.0.3",
                           "from": "cipher-base@>=1.0.1 <2.0.0",
-                          "resolved": "https://registry.npmjs.org/cipher-base/-/cipher-base-1.0.2.tgz"
+                          "resolved": "https://registry.npmjs.org/cipher-base/-/cipher-base-1.0.3.tgz"
                         },
                         "ripemd160": {
                           "version": "1.0.1",
@@ -555,9 +656,9 @@
                       "resolved": "https://registry.npmjs.org/diffie-hellman/-/diffie-hellman-5.0.2.tgz",
                       "dependencies": {
                         "bn.js": {
-                          "version": "4.10.5",
+                          "version": "4.11.6",
                           "from": "bn.js@>=4.1.0 <5.0.0",
-                          "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.10.5.tgz"
+                          "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.6.tgz"
                         },
                         "miller-rabin": {
                           "version": "4.0.0",
@@ -565,18 +666,18 @@
                           "resolved": "https://registry.npmjs.org/miller-rabin/-/miller-rabin-4.0.0.tgz",
                           "dependencies": {
                             "brorand": {
-                              "version": "1.0.5",
+                              "version": "1.0.6",
                               "from": "brorand@>=1.0.1 <2.0.0",
-                              "resolved": "https://registry.npmjs.org/brorand/-/brorand-1.0.5.tgz"
+                              "resolved": "https://registry.npmjs.org/brorand/-/brorand-1.0.6.tgz"
                             }
                           }
                         }
                       }
                     },
                     "pbkdf2": {
-                      "version": "3.0.4",
+                      "version": "3.0.9",
                       "from": "pbkdf2@>=3.0.3 <4.0.0",
-                      "resolved": "https://registry.npmjs.org/pbkdf2/-/pbkdf2-3.0.4.tgz"
+                      "resolved": "https://registry.npmjs.org/pbkdf2/-/pbkdf2-3.0.9.tgz"
                     },
                     "public-encrypt": {
                       "version": "4.0.0",
@@ -584,9 +685,9 @@
                       "resolved": "https://registry.npmjs.org/public-encrypt/-/public-encrypt-4.0.0.tgz",
                       "dependencies": {
                         "bn.js": {
-                          "version": "4.10.5",
+                          "version": "4.11.6",
                           "from": "bn.js@>=4.1.0 <5.0.0",
-                          "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.10.5.tgz"
+                          "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.6.tgz"
                         },
                         "browserify-rsa": {
                           "version": "4.0.1",
@@ -599,9 +700,9 @@
                           "resolved": "https://registry.npmjs.org/parse-asn1/-/parse-asn1-5.0.0.tgz",
                           "dependencies": {
                             "asn1.js": {
-                              "version": "4.5.1",
+                              "version": "4.8.1",
                               "from": "asn1.js@>=4.0.0 <5.0.0",
-                              "resolved": "https://registry.npmjs.org/asn1.js/-/asn1.js-4.5.1.tgz",
+                              "resolved": "https://registry.npmjs.org/asn1.js/-/asn1.js-4.8.1.tgz",
                               "dependencies": {
                                 "minimalistic-assert": {
                                   "version": "1.0.0",
@@ -621,9 +722,9 @@
                                   "resolved": "https://registry.npmjs.org/buffer-xor/-/buffer-xor-1.0.3.tgz"
                                 },
                                 "cipher-base": {
-                                  "version": "1.0.2",
+                                  "version": "1.0.3",
                                   "from": "cipher-base@>=1.0.0 <2.0.0",
-                                  "resolved": "https://registry.npmjs.org/cipher-base/-/cipher-base-1.0.2.tgz"
+                                  "resolved": "https://registry.npmjs.org/cipher-base/-/cipher-base-1.0.3.tgz"
                                 }
                               }
                             },
@@ -637,57 +738,21 @@
                       }
                     },
                     "randombytes": {
-                      "version": "2.0.2",
+                      "version": "2.0.3",
                       "from": "randombytes@>=2.0.0 <3.0.0",
-                      "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.0.2.tgz"
+                      "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.0.3.tgz"
                     }
                   }
-                },
-                "deep-equal": {
-                  "version": "0.2.2",
-                  "from": "deep-equal@>=0.2.1 <0.3.0",
-                  "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-0.2.2.tgz"
                 },
                 "defined": {
-                  "version": "0.0.0",
-                  "from": "defined@>=0.0.0 <0.1.0",
-                  "resolved": "https://registry.npmjs.org/defined/-/defined-0.0.0.tgz"
+                  "version": "1.0.0",
+                  "from": "defined@>=1.0.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/defined/-/defined-1.0.0.tgz"
                 },
                 "deps-sort": {
-                  "version": "1.3.9",
-                  "from": "deps-sort@>=1.3.0 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/deps-sort/-/deps-sort-1.3.9.tgz",
-                  "dependencies": {
-                    "JSONStream": {
-                      "version": "1.0.7",
-                      "from": "JSONStream@>=1.0.3 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-1.0.7.tgz",
-                      "dependencies": {
-                        "jsonparse": {
-                          "version": "1.2.0",
-                          "from": "jsonparse@>=1.1.0 <2.0.0",
-                          "resolved": "https://registry.npmjs.org/jsonparse/-/jsonparse-1.2.0.tgz"
-                        },
-                        "through": {
-                          "version": "2.3.8",
-                          "from": "through@>=2.2.7 <3.0.0",
-                          "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz"
-                        }
-                      }
-                    },
-                    "subarg": {
-                      "version": "1.0.0",
-                      "from": "subarg@>=1.0.0 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/subarg/-/subarg-1.0.0.tgz",
-                      "dependencies": {
-                        "minimist": {
-                          "version": "1.2.0",
-                          "from": "minimist@>=1.1.0 <2.0.0",
-                          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz"
-                        }
-                      }
-                    }
-                  }
+                  "version": "2.0.0",
+                  "from": "deps-sort@>=2.0.0 <3.0.0",
+                  "resolved": "https://registry.npmjs.org/deps-sort/-/deps-sort-2.0.0.tgz"
                 },
                 "domain-browser": {
                   "version": "1.1.7",
@@ -695,38 +760,91 @@
                   "resolved": "https://registry.npmjs.org/domain-browser/-/domain-browser-1.1.7.tgz"
                 },
                 "duplexer2": {
-                  "version": "0.0.2",
-                  "from": "duplexer2@>=0.0.2 <0.1.0",
-                  "resolved": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.0.2.tgz"
+                  "version": "0.1.4",
+                  "from": "duplexer2@>=0.1.2 <0.2.0",
+                  "resolved": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.1.4.tgz"
                 },
                 "events": {
-                  "version": "1.0.2",
-                  "from": "events@>=1.0.0 <1.1.0",
-                  "resolved": "https://registry.npmjs.org/events/-/events-1.0.2.tgz"
+                  "version": "1.1.1",
+                  "from": "events@>=1.1.0 <1.2.0",
+                  "resolved": "https://registry.npmjs.org/events/-/events-1.1.1.tgz"
                 },
                 "glob": {
-                  "version": "3.2.11",
-                  "from": "glob@>=3.2.8 <3.3.0",
-                  "resolved": "https://registry.npmjs.org/glob/-/glob-3.2.11.tgz",
+                  "version": "5.0.15",
+                  "from": "glob@>=5.0.15 <6.0.0",
+                  "resolved": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
                   "dependencies": {
-                    "minimatch": {
-                      "version": "0.3.0",
-                      "from": "minimatch@>=0.3.0 <0.4.0",
-                      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.3.0.tgz",
+                    "inflight": {
+                      "version": "1.0.5",
+                      "from": "inflight@>=1.0.4 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.5.tgz",
                       "dependencies": {
-                        "lru-cache": {
-                          "version": "2.7.3",
-                          "from": "lru-cache@>=2.0.0 <3.0.0",
-                          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.7.3.tgz"
-                        },
-                        "sigmund": {
-                          "version": "1.0.1",
-                          "from": "sigmund@>=1.0.0 <1.1.0",
-                          "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz"
+                        "wrappy": {
+                          "version": "1.0.2",
+                          "from": "wrappy@>=1.0.0 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz"
                         }
                       }
+                    },
+                    "minimatch": {
+                      "version": "3.0.3",
+                      "from": "minimatch@>=2.0.0 <3.0.0||>=3.0.0 <4.0.0",
+                      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.3.tgz",
+                      "dependencies": {
+                        "brace-expansion": {
+                          "version": "1.1.6",
+                          "from": "brace-expansion@>=1.0.0 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.6.tgz",
+                          "dependencies": {
+                            "balanced-match": {
+                              "version": "0.4.2",
+                              "from": "balanced-match@>=0.4.1 <0.5.0",
+                              "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.4.2.tgz"
+                            },
+                            "concat-map": {
+                              "version": "0.0.1",
+                              "from": "concat-map@0.0.1",
+                              "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "once": {
+                      "version": "1.4.0",
+                      "from": "once@>=1.3.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+                      "dependencies": {
+                        "wrappy": {
+                          "version": "1.0.2",
+                          "from": "wrappy@>=1.0.0 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz"
+                        }
+                      }
+                    },
+                    "path-is-absolute": {
+                      "version": "1.0.1",
+                      "from": "path-is-absolute@>=1.0.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz"
                     }
                   }
+                },
+                "has": {
+                  "version": "1.0.1",
+                  "from": "has@>=1.0.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/has/-/has-1.0.1.tgz",
+                  "dependencies": {
+                    "function-bind": {
+                      "version": "1.1.0",
+                      "from": "function-bind@>=1.0.2 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.0.tgz"
+                    }
+                  }
+                },
+                "htmlescape": {
+                  "version": "1.1.1",
+                  "from": "htmlescape@>=1.1.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/htmlescape/-/htmlescape-1.1.1.tgz"
                 },
                 "https-browserify": {
                   "version": "0.0.1",
@@ -734,36 +852,19 @@
                   "resolved": "https://registry.npmjs.org/https-browserify/-/https-browserify-0.0.1.tgz"
                 },
                 "inherits": {
-                  "version": "2.0.1",
+                  "version": "2.0.3",
                   "from": "inherits@>=2.0.1 <2.1.0",
-                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz"
                 },
                 "insert-module-globals": {
-                  "version": "6.6.3",
-                  "from": "insert-module-globals@>=6.1.0 <7.0.0",
-                  "resolved": "https://registry.npmjs.org/insert-module-globals/-/insert-module-globals-6.6.3.tgz",
+                  "version": "7.0.1",
+                  "from": "insert-module-globals@>=7.0.0 <8.0.0",
+                  "resolved": "https://registry.npmjs.org/insert-module-globals/-/insert-module-globals-7.0.1.tgz",
                   "dependencies": {
-                    "JSONStream": {
-                      "version": "1.0.7",
-                      "from": "JSONStream@>=1.0.3 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-1.0.7.tgz",
-                      "dependencies": {
-                        "jsonparse": {
-                          "version": "1.2.0",
-                          "from": "jsonparse@>=1.1.0 <2.0.0",
-                          "resolved": "https://registry.npmjs.org/jsonparse/-/jsonparse-1.2.0.tgz"
-                        },
-                        "through": {
-                          "version": "2.3.8",
-                          "from": "through@>=2.2.7 <3.0.0",
-                          "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz"
-                        }
-                      }
-                    },
                     "combine-source-map": {
-                      "version": "0.6.1",
-                      "from": "combine-source-map@>=0.6.1 <0.7.0",
-                      "resolved": "https://registry.npmjs.org/combine-source-map/-/combine-source-map-0.6.1.tgz",
+                      "version": "0.7.2",
+                      "from": "combine-source-map@>=0.7.1 <0.8.0",
+                      "resolved": "https://registry.npmjs.org/combine-source-map/-/combine-source-map-0.7.2.tgz",
                       "dependencies": {
                         "convert-source-map": {
                           "version": "1.1.3",
@@ -771,9 +872,9 @@
                           "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.1.3.tgz"
                         },
                         "inline-source-map": {
-                          "version": "0.5.0",
-                          "from": "inline-source-map@>=0.5.0 <0.6.0",
-                          "resolved": "https://registry.npmjs.org/inline-source-map/-/inline-source-map-0.5.0.tgz"
+                          "version": "0.6.2",
+                          "from": "inline-source-map@>=0.6.0 <0.7.0",
+                          "resolved": "https://registry.npmjs.org/inline-source-map/-/inline-source-map-0.6.2.tgz"
                         },
                         "lodash.memoize": {
                           "version": "3.0.4",
@@ -781,23 +882,16 @@
                           "resolved": "https://registry.npmjs.org/lodash.memoize/-/lodash.memoize-3.0.4.tgz"
                         },
                         "source-map": {
-                          "version": "0.4.4",
-                          "from": "source-map@>=0.4.2 <0.5.0",
-                          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz",
-                          "dependencies": {
-                            "amdefine": {
-                              "version": "1.0.0",
-                              "from": "amdefine@>=0.0.4",
-                              "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.0.tgz"
-                            }
-                          }
+                          "version": "0.5.6",
+                          "from": "source-map@>=0.5.3 <0.6.0",
+                          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz"
                         }
                       }
                     },
                     "is-buffer": {
-                      "version": "1.1.2",
+                      "version": "1.1.4",
                       "from": "is-buffer@>=1.1.0 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.2.tgz"
+                      "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.4.tgz"
                     },
                     "lexical-scope": {
                       "version": "1.2.0",
@@ -817,75 +911,31 @@
                           }
                         }
                       }
-                    },
-                    "process": {
-                      "version": "0.11.2",
-                      "from": "process@>=0.11.0 <0.12.0",
-                      "resolved": "https://registry.npmjs.org/process/-/process-0.11.2.tgz"
-                    },
-                    "xtend": {
-                      "version": "4.0.1",
-                      "from": "xtend@>=4.0.0 <5.0.0",
-                      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz"
                     }
                   }
                 },
-                "isarray": {
-                  "version": "0.0.1",
-                  "from": "isarray@0.0.1",
-                  "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
-                },
                 "labeled-stream-splicer": {
-                  "version": "1.0.2",
-                  "from": "labeled-stream-splicer@>=1.0.0 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/labeled-stream-splicer/-/labeled-stream-splicer-1.0.2.tgz",
+                  "version": "2.0.0",
+                  "from": "labeled-stream-splicer@>=2.0.0 <3.0.0",
+                  "resolved": "https://registry.npmjs.org/labeled-stream-splicer/-/labeled-stream-splicer-2.0.0.tgz",
                   "dependencies": {
+                    "isarray": {
+                      "version": "0.0.1",
+                      "from": "isarray@>=0.0.1 <0.1.0",
+                      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                    },
                     "stream-splicer": {
-                      "version": "1.3.2",
-                      "from": "stream-splicer@>=1.1.0 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/stream-splicer/-/stream-splicer-1.3.2.tgz",
-                      "dependencies": {
-                        "readable-wrap": {
-                          "version": "1.0.0",
-                          "from": "readable-wrap@>=1.0.0 <2.0.0",
-                          "resolved": "https://registry.npmjs.org/readable-wrap/-/readable-wrap-1.0.0.tgz"
-                        },
-                        "indexof": {
-                          "version": "0.0.1",
-                          "from": "indexof@0.0.1",
-                          "resolved": "https://registry.npmjs.org/indexof/-/indexof-0.0.1.tgz"
-                        }
-                      }
+                      "version": "2.0.0",
+                      "from": "stream-splicer@>=2.0.0 <3.0.0",
+                      "resolved": "https://registry.npmjs.org/stream-splicer/-/stream-splicer-2.0.0.tgz"
                     }
                   }
                 },
                 "module-deps": {
-                  "version": "3.9.1",
-                  "from": "module-deps@>=3.5.0 <4.0.0",
-                  "resolved": "https://registry.npmjs.org/module-deps/-/module-deps-3.9.1.tgz",
+                  "version": "4.0.7",
+                  "from": "module-deps@>=4.0.2 <5.0.0",
+                  "resolved": "https://registry.npmjs.org/module-deps/-/module-deps-4.0.7.tgz",
                   "dependencies": {
-                    "JSONStream": {
-                      "version": "1.0.7",
-                      "from": "JSONStream@>=1.0.3 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-1.0.7.tgz",
-                      "dependencies": {
-                        "jsonparse": {
-                          "version": "1.2.0",
-                          "from": "jsonparse@>=1.1.0 <2.0.0",
-                          "resolved": "https://registry.npmjs.org/jsonparse/-/jsonparse-1.2.0.tgz"
-                        },
-                        "through": {
-                          "version": "2.3.8",
-                          "from": "through@>=2.2.7 <3.0.0",
-                          "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz"
-                        }
-                      }
-                    },
-                    "defined": {
-                      "version": "1.0.0",
-                      "from": "defined@>=1.0.0 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/defined/-/defined-1.0.0.tgz"
-                    },
                     "detective": {
                       "version": "4.3.1",
                       "from": "detective@>=4.0.0 <5.0.0",
@@ -898,75 +948,10 @@
                         }
                       }
                     },
-                    "parents": {
-                      "version": "1.0.1",
-                      "from": "parents@>=1.0.0 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/parents/-/parents-1.0.1.tgz",
-                      "dependencies": {
-                        "path-platform": {
-                          "version": "0.11.15",
-                          "from": "path-platform@>=0.11.15 <0.12.0",
-                          "resolved": "https://registry.npmjs.org/path-platform/-/path-platform-0.11.15.tgz"
-                        }
-                      }
-                    },
-                    "resolve": {
-                      "version": "1.1.7",
-                      "from": "resolve@>=1.1.3 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.1.7.tgz"
-                    },
                     "stream-combiner2": {
-                      "version": "1.0.2",
-                      "from": "stream-combiner2@>=1.0.0 <1.1.0",
-                      "resolved": "https://registry.npmjs.org/stream-combiner2/-/stream-combiner2-1.0.2.tgz",
-                      "dependencies": {
-                        "through2": {
-                          "version": "0.5.1",
-                          "from": "through2@>=0.5.1 <0.6.0",
-                          "resolved": "https://registry.npmjs.org/through2/-/through2-0.5.1.tgz",
-                          "dependencies": {
-                            "readable-stream": {
-                              "version": "1.0.33",
-                              "from": "readable-stream@>=1.0.17 <1.1.0",
-                              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
-                              "dependencies": {
-                                "core-util-is": {
-                                  "version": "1.0.2",
-                                  "from": "core-util-is@>=1.0.0 <1.1.0",
-                                  "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
-                                },
-                                "string_decoder": {
-                                  "version": "0.10.31",
-                                  "from": "string_decoder@>=0.10.0 <0.11.0",
-                                  "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
-                                }
-                              }
-                            },
-                            "xtend": {
-                              "version": "3.0.0",
-                              "from": "xtend@>=3.0.0 <3.1.0",
-                              "resolved": "https://registry.npmjs.org/xtend/-/xtend-3.0.0.tgz"
-                            }
-                          }
-                        }
-                      }
-                    },
-                    "subarg": {
-                      "version": "1.0.0",
-                      "from": "subarg@>=1.0.0 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/subarg/-/subarg-1.0.0.tgz",
-                      "dependencies": {
-                        "minimist": {
-                          "version": "1.2.0",
-                          "from": "minimist@>=1.1.0 <2.0.0",
-                          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz"
-                        }
-                      }
-                    },
-                    "xtend": {
-                      "version": "4.0.1",
-                      "from": "xtend@>=4.0.0 <5.0.0",
-                      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz"
+                      "version": "1.1.1",
+                      "from": "stream-combiner2@>=1.1.1 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/stream-combiner2/-/stream-combiner2-1.1.1.tgz"
                     }
                   }
                 },
@@ -976,14 +961,14 @@
                   "resolved": "https://registry.npmjs.org/os-browserify/-/os-browserify-0.1.2.tgz"
                 },
                 "parents": {
-                  "version": "0.0.3",
-                  "from": "parents@>=0.0.1 <0.1.0",
-                  "resolved": "https://registry.npmjs.org/parents/-/parents-0.0.3.tgz",
+                  "version": "1.0.1",
+                  "from": "parents@>=1.0.1 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/parents/-/parents-1.0.1.tgz",
                   "dependencies": {
                     "path-platform": {
-                      "version": "0.0.1",
-                      "from": "path-platform@>=0.0.1 <0.0.2",
-                      "resolved": "https://registry.npmjs.org/path-platform/-/path-platform-0.0.1.tgz"
+                      "version": "0.11.15",
+                      "from": "path-platform@>=0.11.15 <0.12.0",
+                      "resolved": "https://registry.npmjs.org/path-platform/-/path-platform-0.11.15.tgz"
                     }
                   }
                 },
@@ -993,46 +978,61 @@
                   "resolved": "https://registry.npmjs.org/path-browserify/-/path-browserify-0.0.0.tgz"
                 },
                 "process": {
-                  "version": "0.7.0",
-                  "from": "process@>=0.7.0 <0.8.0",
-                  "resolved": "https://registry.npmjs.org/process/-/process-0.7.0.tgz"
+                  "version": "0.11.9",
+                  "from": "process@>=0.11.0 <0.12.0",
+                  "resolved": "https://registry.npmjs.org/process/-/process-0.11.9.tgz"
                 },
                 "punycode": {
-                  "version": "1.2.4",
-                  "from": "punycode@>=1.2.3 <1.3.0",
-                  "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.2.4.tgz"
+                  "version": "1.4.1",
+                  "from": "punycode@>=1.3.2 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz"
                 },
                 "querystring-es3": {
                   "version": "0.2.1",
                   "from": "querystring-es3@>=0.2.0 <0.3.0",
                   "resolved": "https://registry.npmjs.org/querystring-es3/-/querystring-es3-0.2.1.tgz"
                 },
+                "read-only-stream": {
+                  "version": "2.0.0",
+                  "from": "read-only-stream@>=2.0.0 <3.0.0",
+                  "resolved": "https://registry.npmjs.org/read-only-stream/-/read-only-stream-2.0.0.tgz"
+                },
                 "readable-stream": {
-                  "version": "1.1.13",
-                  "from": "readable-stream@>=1.0.27-1 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz",
+                  "version": "2.1.5",
+                  "from": "readable-stream@>=2.0.2 <3.0.0",
+                  "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.1.5.tgz",
                   "dependencies": {
+                    "buffer-shims": {
+                      "version": "1.0.0",
+                      "from": "buffer-shims@>=1.0.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/buffer-shims/-/buffer-shims-1.0.0.tgz"
+                    },
                     "core-util-is": {
                       "version": "1.0.2",
                       "from": "core-util-is@>=1.0.0 <1.1.0",
                       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
                     },
-                    "string_decoder": {
-                      "version": "0.10.31",
-                      "from": "string_decoder@>=0.10.0 <0.11.0",
-                      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+                    "isarray": {
+                      "version": "1.0.0",
+                      "from": "isarray@>=1.0.0 <1.1.0",
+                      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz"
+                    },
+                    "process-nextick-args": {
+                      "version": "1.0.7",
+                      "from": "process-nextick-args@>=1.0.6 <1.1.0",
+                      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz"
+                    },
+                    "util-deprecate": {
+                      "version": "1.0.2",
+                      "from": "util-deprecate@>=1.0.1 <1.1.0",
+                      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz"
                     }
                   }
                 },
                 "resolve": {
-                  "version": "0.7.4",
-                  "from": "resolve@>=0.7.1 <0.8.0",
-                  "resolved": "https://registry.npmjs.org/resolve/-/resolve-0.7.4.tgz"
-                },
-                "shallow-copy": {
-                  "version": "0.0.1",
-                  "from": "shallow-copy@0.0.1",
-                  "resolved": "https://registry.npmjs.org/shallow-copy/-/shallow-copy-0.0.1.tgz"
+                  "version": "1.1.7",
+                  "from": "resolve@>=1.1.4 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.1.7.tgz"
                 },
                 "shasum": {
                   "version": "1.0.2",
@@ -1059,48 +1059,75 @@
                   }
                 },
                 "shell-quote": {
-                  "version": "0.0.1",
-                  "from": "shell-quote@>=0.0.1 <0.1.0",
-                  "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-0.0.1.tgz"
+                  "version": "1.6.1",
+                  "from": "shell-quote@>=1.4.3 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.6.1.tgz",
+                  "dependencies": {
+                    "jsonify": {
+                      "version": "0.0.0",
+                      "from": "jsonify@>=0.0.0 <0.1.0",
+                      "resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz"
+                    },
+                    "array-filter": {
+                      "version": "0.0.1",
+                      "from": "array-filter@>=0.0.0 <0.1.0",
+                      "resolved": "https://registry.npmjs.org/array-filter/-/array-filter-0.0.1.tgz"
+                    },
+                    "array-reduce": {
+                      "version": "0.0.0",
+                      "from": "array-reduce@>=0.0.0 <0.1.0",
+                      "resolved": "https://registry.npmjs.org/array-reduce/-/array-reduce-0.0.0.tgz"
+                    },
+                    "array-map": {
+                      "version": "0.0.0",
+                      "from": "array-map@>=0.0.0 <0.1.0",
+                      "resolved": "https://registry.npmjs.org/array-map/-/array-map-0.0.0.tgz"
+                    }
+                  }
                 },
                 "stream-browserify": {
-                  "version": "1.0.0",
-                  "from": "stream-browserify@>=1.0.0 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/stream-browserify/-/stream-browserify-1.0.0.tgz"
+                  "version": "2.0.1",
+                  "from": "stream-browserify@>=2.0.0 <3.0.0",
+                  "resolved": "https://registry.npmjs.org/stream-browserify/-/stream-browserify-2.0.1.tgz"
                 },
-                "stream-combiner": {
-                  "version": "0.0.4",
-                  "from": "stream-combiner@>=0.0.2 <0.1.0",
-                  "resolved": "https://registry.npmjs.org/stream-combiner/-/stream-combiner-0.0.4.tgz",
+                "stream-http": {
+                  "version": "2.4.0",
+                  "from": "stream-http@>=2.0.0 <3.0.0",
+                  "resolved": "https://registry.npmjs.org/stream-http/-/stream-http-2.4.0.tgz",
                   "dependencies": {
-                    "duplexer": {
-                      "version": "0.1.1",
-                      "from": "duplexer@>=0.1.1 <0.2.0",
-                      "resolved": "https://registry.npmjs.org/duplexer/-/duplexer-0.1.1.tgz"
+                    "builtin-status-codes": {
+                      "version": "2.0.0",
+                      "from": "builtin-status-codes@>=2.0.0 <3.0.0",
+                      "resolved": "https://registry.npmjs.org/builtin-status-codes/-/builtin-status-codes-2.0.0.tgz"
+                    },
+                    "to-arraybuffer": {
+                      "version": "1.0.1",
+                      "from": "to-arraybuffer@>=1.0.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/to-arraybuffer/-/to-arraybuffer-1.0.1.tgz"
                     }
                   }
                 },
                 "string_decoder": {
-                  "version": "0.0.1",
-                  "from": "string_decoder@>=0.0.0 <0.1.0",
-                  "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.0.1.tgz"
+                  "version": "0.10.31",
+                  "from": "string_decoder@>=0.10.0 <0.11.0",
+                  "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
                 },
                 "subarg": {
-                  "version": "0.0.1",
-                  "from": "subarg@0.0.1",
-                  "resolved": "https://registry.npmjs.org/subarg/-/subarg-0.0.1.tgz",
+                  "version": "1.0.0",
+                  "from": "subarg@>=1.0.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/subarg/-/subarg-1.0.0.tgz",
                   "dependencies": {
                     "minimist": {
-                      "version": "0.0.10",
-                      "from": "minimist@>=0.0.7 <0.1.0",
-                      "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz"
+                      "version": "1.2.0",
+                      "from": "minimist@>=1.1.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz"
                     }
                   }
                 },
                 "syntax-error": {
-                  "version": "1.1.5",
+                  "version": "1.1.6",
                   "from": "syntax-error@>=1.1.1 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/syntax-error/-/syntax-error-1.1.5.tgz",
+                  "resolved": "https://registry.npmjs.org/syntax-error/-/syntax-error-1.1.6.tgz",
                   "dependencies": {
                     "acorn": {
                       "version": "2.7.0",
@@ -1110,105 +1137,53 @@
                   }
                 },
                 "through2": {
-                  "version": "1.1.1",
-                  "from": "through2@>=1.0.0 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/through2/-/through2-1.1.1.tgz",
+                  "version": "2.0.1",
+                  "from": "through2@>=2.0.0 <3.0.0",
+                  "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.1.tgz",
                   "dependencies": {
-                    "xtend": {
-                      "version": "4.0.1",
-                      "from": "xtend@>=4.0.0 <5.0.0",
-                      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz"
+                    "readable-stream": {
+                      "version": "2.0.6",
+                      "from": "readable-stream@>=2.0.0 <2.1.0",
+                      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.6.tgz",
+                      "dependencies": {
+                        "core-util-is": {
+                          "version": "1.0.2",
+                          "from": "core-util-is@>=1.0.0 <1.1.0",
+                          "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
+                        },
+                        "isarray": {
+                          "version": "1.0.0",
+                          "from": "isarray@>=1.0.0 <1.1.0",
+                          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz"
+                        },
+                        "process-nextick-args": {
+                          "version": "1.0.7",
+                          "from": "process-nextick-args@>=1.0.6 <1.1.0",
+                          "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz"
+                        },
+                        "util-deprecate": {
+                          "version": "1.0.2",
+                          "from": "util-deprecate@>=1.0.1 <1.1.0",
+                          "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz"
+                        }
+                      }
                     }
                   }
                 },
                 "timers-browserify": {
                   "version": "1.4.2",
                   "from": "timers-browserify@>=1.0.1 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/timers-browserify/-/timers-browserify-1.4.2.tgz",
-                  "dependencies": {
-                    "process": {
-                      "version": "0.11.2",
-                      "from": "process@>=0.11.0 <0.12.0",
-                      "resolved": "https://registry.npmjs.org/process/-/process-0.11.2.tgz"
-                    }
-                  }
+                  "resolved": "https://registry.npmjs.org/timers-browserify/-/timers-browserify-1.4.2.tgz"
                 },
                 "tty-browserify": {
                   "version": "0.0.0",
                   "from": "tty-browserify@>=0.0.0 <0.1.0",
                   "resolved": "https://registry.npmjs.org/tty-browserify/-/tty-browserify-0.0.0.tgz"
                 },
-                "umd": {
-                  "version": "2.1.0",
-                  "from": "umd@>=2.1.0 <2.2.0",
-                  "resolved": "https://registry.npmjs.org/umd/-/umd-2.1.0.tgz",
-                  "dependencies": {
-                    "rfile": {
-                      "version": "1.0.0",
-                      "from": "rfile@>=1.0.0 <1.1.0",
-                      "resolved": "https://registry.npmjs.org/rfile/-/rfile-1.0.0.tgz",
-                      "dependencies": {
-                        "callsite": {
-                          "version": "1.0.0",
-                          "from": "callsite@>=1.0.0 <1.1.0",
-                          "resolved": "https://registry.npmjs.org/callsite/-/callsite-1.0.0.tgz"
-                        },
-                        "resolve": {
-                          "version": "0.3.1",
-                          "from": "resolve@>=0.3.0 <0.4.0",
-                          "resolved": "https://registry.npmjs.org/resolve/-/resolve-0.3.1.tgz"
-                        }
-                      }
-                    },
-                    "ruglify": {
-                      "version": "1.0.0",
-                      "from": "ruglify@>=1.0.0 <1.1.0",
-                      "resolved": "https://registry.npmjs.org/ruglify/-/ruglify-1.0.0.tgz",
-                      "dependencies": {
-                        "uglify-js": {
-                          "version": "2.2.5",
-                          "from": "uglify-js@>=2.2.0 <2.3.0",
-                          "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.2.5.tgz",
-                          "dependencies": {
-                            "source-map": {
-                              "version": "0.1.43",
-                              "from": "source-map@>=0.1.7 <0.2.0",
-                              "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.43.tgz",
-                              "dependencies": {
-                                "amdefine": {
-                                  "version": "1.0.0",
-                                  "from": "amdefine@>=0.0.4",
-                                  "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.0.tgz"
-                                }
-                              }
-                            },
-                            "optimist": {
-                              "version": "0.3.7",
-                              "from": "optimist@>=0.3.5 <0.4.0",
-                              "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.3.7.tgz",
-                              "dependencies": {
-                                "wordwrap": {
-                                  "version": "0.0.3",
-                                  "from": "wordwrap@>=0.0.2 <0.1.0",
-                                  "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz"
-                                }
-                              }
-                            }
-                          }
-                        }
-                      }
-                    },
-                    "through": {
-                      "version": "2.3.8",
-                      "from": "through@>=2.3.4 <2.4.0",
-                      "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz"
-                    }
-                  }
-                },
                 "url": {
-                  "version": "0.10.3",
-                  "from": "url@>=0.10.1 <0.11.0",
-                  "resolved": "https://registry.npmjs.org/url/-/url-0.10.3.tgz",
+                  "version": "0.11.0",
+                  "from": "url@>=0.11.0 <0.12.0",
+                  "resolved": "https://registry.npmjs.org/url/-/url-0.11.0.tgz",
                   "dependencies": {
                     "punycode": {
                       "version": "1.3.2",
@@ -1225,7 +1200,14 @@
                 "util": {
                   "version": "0.10.3",
                   "from": "util@>=0.10.1 <0.11.0",
-                  "resolved": "https://registry.npmjs.org/util/-/util-0.10.3.tgz"
+                  "resolved": "https://registry.npmjs.org/util/-/util-0.10.3.tgz",
+                  "dependencies": {
+                    "inherits": {
+                      "version": "2.0.1",
+                      "from": "inherits@2.0.1",
+                      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                    }
+                  }
                 },
                 "vm-browserify": {
                   "version": "0.0.4",
@@ -1240,16 +1222,16 @@
                   }
                 },
                 "xtend": {
-                  "version": "3.0.0",
-                  "from": "xtend@>=3.0.0 <4.0.0",
-                  "resolved": "https://registry.npmjs.org/xtend/-/xtend-3.0.0.tgz"
+                  "version": "4.0.1",
+                  "from": "xtend@>=4.0.0 <5.0.0",
+                  "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz"
                 }
               }
             },
             "http-browserify": {
-              "version": "1.4.1",
-              "from": "http-browserify@1.4.1",
-              "resolved": "https://registry.npmjs.org/http-browserify/-/http-browserify-1.4.1.tgz",
+              "version": "1.7.0",
+              "from": "http-browserify@1.7.0",
+              "resolved": "https://registry.npmjs.org/http-browserify/-/http-browserify-1.7.0.tgz",
               "dependencies": {
                 "Base64": {
                   "version": "0.2.1",
@@ -1257,132 +1239,706 @@
                   "resolved": "https://registry.npmjs.org/Base64/-/Base64-0.2.1.tgz"
                 },
                 "inherits": {
-                  "version": "2.0.1",
+                  "version": "2.0.3",
                   "from": "inherits@>=2.0.1 <2.1.0",
-                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz"
                 }
               }
             },
-            "vows": {
-              "version": "0.7.0",
-              "from": "vows@0.7.0",
-              "resolved": "https://registry.npmjs.org/vows/-/vows-0.7.0.tgz",
+            "vows-without-nsp-warnings": {
+              "version": "0.10.0",
+              "from": "vows-without-nsp-warnings@0.10.0",
+              "resolved": "https://registry.npmjs.org/vows-without-nsp-warnings/-/vows-without-nsp-warnings-0.10.0.tgz",
               "dependencies": {
                 "eyes": {
                   "version": "0.1.8",
-                  "from": "eyes@>=0.1.6",
+                  "from": "eyes@>=0.1.6 <0.2.0",
                   "resolved": "https://registry.npmjs.org/eyes/-/eyes-0.1.8.tgz"
                 },
                 "diff": {
-                  "version": "1.0.8",
-                  "from": "diff@>=1.0.3 <1.1.0",
-                  "resolved": "https://registry.npmjs.org/diff/-/diff-1.0.8.tgz"
-                }
-              }
-            },
-            "optimist": {
-              "version": "0.6.1",
-              "from": "optimist@0.6.1",
-              "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
-              "dependencies": {
-                "wordwrap": {
-                  "version": "0.0.3",
-                  "from": "wordwrap@>=0.0.2 <0.1.0",
-                  "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz"
+                  "version": "1.2.2",
+                  "from": "diff@>=1.2.0 <1.3.0",
+                  "resolved": "https://registry.npmjs.org/diff/-/diff-1.2.2.tgz"
                 },
-                "minimist": {
-                  "version": "0.0.10",
-                  "from": "minimist@>=0.0.1 <0.1.0",
-                  "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz"
+                "glob": {
+                  "version": "7.1.1",
+                  "from": "glob@>=7.1.1 <7.2.0",
+                  "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.1.tgz",
+                  "dependencies": {
+                    "fs.realpath": {
+                      "version": "1.0.0",
+                      "from": "fs.realpath@>=1.0.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz"
+                    },
+                    "inflight": {
+                      "version": "1.0.5",
+                      "from": "inflight@>=1.0.4 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.5.tgz",
+                      "dependencies": {
+                        "wrappy": {
+                          "version": "1.0.2",
+                          "from": "wrappy@>=1.0.0 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz"
+                        }
+                      }
+                    },
+                    "inherits": {
+                      "version": "2.0.3",
+                      "from": "inherits@>=2.0.0 <3.0.0",
+                      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz"
+                    },
+                    "minimatch": {
+                      "version": "3.0.3",
+                      "from": "minimatch@>=3.0.2 <4.0.0",
+                      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.3.tgz",
+                      "dependencies": {
+                        "brace-expansion": {
+                          "version": "1.1.6",
+                          "from": "brace-expansion@>=1.0.0 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.6.tgz",
+                          "dependencies": {
+                            "balanced-match": {
+                              "version": "0.4.2",
+                              "from": "balanced-match@>=0.4.1 <0.5.0",
+                              "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.4.2.tgz"
+                            },
+                            "concat-map": {
+                              "version": "0.0.1",
+                              "from": "concat-map@0.0.1",
+                              "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "once": {
+                      "version": "1.4.0",
+                      "from": "once@>=1.3.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+                      "dependencies": {
+                        "wrappy": {
+                          "version": "1.0.2",
+                          "from": "wrappy@>=1.0.0 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz"
+                        }
+                      }
+                    },
+                    "path-is-absolute": {
+                      "version": "1.0.1",
+                      "from": "path-is-absolute@>=1.0.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz"
+                    }
+                  }
                 }
               }
             },
             "uglify-js": {
-              "version": "2.4.15",
-              "from": "uglify-js@2.4.15",
-              "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.4.15.tgz",
+              "version": "2.7.3",
+              "from": "uglify-js@2.7.3",
+              "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.7.3.tgz",
               "dependencies": {
-                "source-map": {
-                  "version": "0.1.34",
-                  "from": "source-map@0.1.34",
-                  "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.34.tgz",
-                  "dependencies": {
-                    "amdefine": {
-                      "version": "1.0.0",
-                      "from": "amdefine@>=0.0.4",
-                      "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.0.tgz"
-                    }
-                  }
+                "async": {
+                  "version": "0.2.10",
+                  "from": "async@>=0.2.6 <0.3.0",
+                  "resolved": "https://registry.npmjs.org/async/-/async-0.2.10.tgz"
                 },
-                "optimist": {
-                  "version": "0.3.7",
-                  "from": "optimist@>=0.3.5 <0.4.0",
-                  "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.3.7.tgz",
-                  "dependencies": {
-                    "wordwrap": {
-                      "version": "0.0.3",
-                      "from": "wordwrap@>=0.0.2 <0.1.0",
-                      "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz"
-                    }
-                  }
+                "source-map": {
+                  "version": "0.5.6",
+                  "from": "source-map@>=0.5.1 <0.6.0",
+                  "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz"
                 },
                 "uglify-to-browserify": {
                   "version": "1.0.2",
                   "from": "uglify-to-browserify@>=1.0.0 <1.1.0",
                   "resolved": "https://registry.npmjs.org/uglify-to-browserify/-/uglify-to-browserify-1.0.2.tgz"
+                },
+                "yargs": {
+                  "version": "3.10.0",
+                  "from": "yargs@>=3.10.0 <3.11.0",
+                  "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.10.0.tgz",
+                  "dependencies": {
+                    "camelcase": {
+                      "version": "1.2.1",
+                      "from": "camelcase@>=1.0.2 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz"
+                    },
+                    "cliui": {
+                      "version": "2.1.0",
+                      "from": "cliui@>=2.1.0 <3.0.0",
+                      "resolved": "https://registry.npmjs.org/cliui/-/cliui-2.1.0.tgz",
+                      "dependencies": {
+                        "center-align": {
+                          "version": "0.1.3",
+                          "from": "center-align@>=0.1.1 <0.2.0",
+                          "resolved": "https://registry.npmjs.org/center-align/-/center-align-0.1.3.tgz",
+                          "dependencies": {
+                            "align-text": {
+                              "version": "0.1.4",
+                              "from": "align-text@>=0.1.1 <0.2.0",
+                              "resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
+                              "dependencies": {
+                                "kind-of": {
+                                  "version": "3.0.4",
+                                  "from": "kind-of@>=3.0.2 <4.0.0",
+                                  "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.0.4.tgz",
+                                  "dependencies": {
+                                    "is-buffer": {
+                                      "version": "1.1.4",
+                                      "from": "is-buffer@>=1.0.2 <2.0.0",
+                                      "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.4.tgz"
+                                    }
+                                  }
+                                },
+                                "longest": {
+                                  "version": "1.0.1",
+                                  "from": "longest@>=1.0.1 <2.0.0",
+                                  "resolved": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz"
+                                },
+                                "repeat-string": {
+                                  "version": "1.5.4",
+                                  "from": "repeat-string@>=1.5.2 <2.0.0",
+                                  "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.5.4.tgz"
+                                }
+                              }
+                            },
+                            "lazy-cache": {
+                              "version": "1.0.4",
+                              "from": "lazy-cache@>=1.0.3 <2.0.0",
+                              "resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-1.0.4.tgz"
+                            }
+                          }
+                        },
+                        "right-align": {
+                          "version": "0.1.3",
+                          "from": "right-align@>=0.1.1 <0.2.0",
+                          "resolved": "https://registry.npmjs.org/right-align/-/right-align-0.1.3.tgz",
+                          "dependencies": {
+                            "align-text": {
+                              "version": "0.1.4",
+                              "from": "align-text@>=0.1.1 <0.2.0",
+                              "resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
+                              "dependencies": {
+                                "kind-of": {
+                                  "version": "3.0.4",
+                                  "from": "kind-of@>=3.0.2 <4.0.0",
+                                  "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.0.4.tgz",
+                                  "dependencies": {
+                                    "is-buffer": {
+                                      "version": "1.1.4",
+                                      "from": "is-buffer@>=1.0.2 <2.0.0",
+                                      "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.4.tgz"
+                                    }
+                                  }
+                                },
+                                "longest": {
+                                  "version": "1.0.1",
+                                  "from": "longest@>=1.0.1 <2.0.0",
+                                  "resolved": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz"
+                                },
+                                "repeat-string": {
+                                  "version": "1.5.4",
+                                  "from": "repeat-string@>=1.5.2 <2.0.0",
+                                  "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.5.4.tgz"
+                                }
+                              }
+                            }
+                          }
+                        },
+                        "wordwrap": {
+                          "version": "0.0.2",
+                          "from": "wordwrap@0.0.2",
+                          "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz"
+                        }
+                      }
+                    },
+                    "decamelize": {
+                      "version": "1.2.0",
+                      "from": "decamelize@>=1.0.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz"
+                    },
+                    "window-size": {
+                      "version": "0.1.0",
+                      "from": "window-size@0.1.0",
+                      "resolved": "https://registry.npmjs.org/window-size/-/window-size-0.1.0.tgz"
+                    }
+                  }
                 }
               }
             },
             "bignum": {
-              "version": "0.11.0",
-              "from": "bignum@0.11.0",
-              "resolved": "https://registry.npmjs.org/bignum/-/bignum-0.11.0.tgz",
+              "version": "0.12.5",
+              "from": "bignum@0.12.5",
+              "resolved": "https://registry.npmjs.org/bignum/-/bignum-0.12.5.tgz",
               "dependencies": {
                 "nan": {
-                  "version": "2.2.0",
-                  "from": "nan@>=2.0.0 <3.0.0",
-                  "resolved": "https://registry.npmjs.org/nan/-/nan-2.2.0.tgz"
+                  "version": "2.4.0",
+                  "from": "nan@>=2.3.4 <3.0.0",
+                  "resolved": "https://registry.npmjs.org/nan/-/nan-2.4.0.tgz"
+                },
+                "node-pre-gyp": {
+                  "version": "0.6.30",
+                  "from": "node-pre-gyp@>=0.6.28 <0.7.0",
+                  "resolved": "https://registry.npmjs.org/node-pre-gyp/-/node-pre-gyp-0.6.30.tgz",
+                  "dependencies": {
+                    "mkdirp": {
+                      "version": "0.5.1",
+                      "from": "mkdirp@>=0.5.0 <0.6.0",
+                      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+                      "dependencies": {
+                        "minimist": {
+                          "version": "0.0.8",
+                          "from": "minimist@0.0.8",
+                          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
+                        }
+                      }
+                    },
+                    "nopt": {
+                      "version": "3.0.6",
+                      "from": "nopt@>=3.0.1 <3.1.0",
+                      "resolved": "https://registry.npmjs.org/nopt/-/nopt-3.0.6.tgz",
+                      "dependencies": {
+                        "abbrev": {
+                          "version": "1.0.9",
+                          "from": "abbrev@>=1.0.0 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.9.tgz"
+                        }
+                      }
+                    },
+                    "npmlog": {
+                      "version": "4.0.0",
+                      "from": "npmlog@>=4.0.0 <5.0.0",
+                      "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-4.0.0.tgz",
+                      "dependencies": {
+                        "are-we-there-yet": {
+                          "version": "1.1.2",
+                          "from": "are-we-there-yet@>=1.1.2 <1.2.0",
+                          "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.2.tgz",
+                          "dependencies": {
+                            "delegates": {
+                              "version": "1.0.0",
+                              "from": "delegates@>=1.0.0 <2.0.0",
+                              "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz"
+                            },
+                            "readable-stream": {
+                              "version": "2.1.5",
+                              "from": "readable-stream@>=2.0.0 <3.0.0||>=1.1.13 <2.0.0",
+                              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.1.5.tgz",
+                              "dependencies": {
+                                "buffer-shims": {
+                                  "version": "1.0.0",
+                                  "from": "buffer-shims@>=1.0.0 <2.0.0",
+                                  "resolved": "https://registry.npmjs.org/buffer-shims/-/buffer-shims-1.0.0.tgz"
+                                },
+                                "core-util-is": {
+                                  "version": "1.0.2",
+                                  "from": "core-util-is@>=1.0.0 <1.1.0",
+                                  "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
+                                },
+                                "inherits": {
+                                  "version": "2.0.3",
+                                  "from": "inherits@>=2.0.1 <2.1.0",
+                                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz"
+                                },
+                                "isarray": {
+                                  "version": "1.0.0",
+                                  "from": "isarray@>=1.0.0 <1.1.0",
+                                  "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz"
+                                },
+                                "process-nextick-args": {
+                                  "version": "1.0.7",
+                                  "from": "process-nextick-args@>=1.0.6 <1.1.0",
+                                  "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz"
+                                },
+                                "string_decoder": {
+                                  "version": "0.10.31",
+                                  "from": "string_decoder@>=0.10.0 <0.11.0",
+                                  "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+                                },
+                                "util-deprecate": {
+                                  "version": "1.0.2",
+                                  "from": "util-deprecate@>=1.0.1 <1.1.0",
+                                  "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz"
+                                }
+                              }
+                            }
+                          }
+                        },
+                        "console-control-strings": {
+                          "version": "1.1.0",
+                          "from": "console-control-strings@>=1.1.0 <1.2.0",
+                          "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz"
+                        },
+                        "gauge": {
+                          "version": "2.6.0",
+                          "from": "gauge@>=2.6.0 <2.7.0",
+                          "resolved": "https://registry.npmjs.org/gauge/-/gauge-2.6.0.tgz",
+                          "dependencies": {
+                            "aproba": {
+                              "version": "1.0.4",
+                              "from": "aproba@>=1.0.3 <2.0.0",
+                              "resolved": "https://registry.npmjs.org/aproba/-/aproba-1.0.4.tgz"
+                            },
+                            "has-color": {
+                              "version": "0.1.7",
+                              "from": "has-color@>=0.1.7 <0.2.0",
+                              "resolved": "https://registry.npmjs.org/has-color/-/has-color-0.1.7.tgz"
+                            },
+                            "has-unicode": {
+                              "version": "2.0.1",
+                              "from": "has-unicode@>=2.0.0 <3.0.0",
+                              "resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz"
+                            },
+                            "object-assign": {
+                              "version": "4.1.0",
+                              "from": "object-assign@>=4.1.0 <5.0.0",
+                              "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.0.tgz"
+                            },
+                            "signal-exit": {
+                              "version": "3.0.1",
+                              "from": "signal-exit@>=3.0.0 <4.0.0",
+                              "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.1.tgz"
+                            },
+                            "string-width": {
+                              "version": "1.0.2",
+                              "from": "string-width@>=1.0.1 <2.0.0",
+                              "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+                              "dependencies": {
+                                "code-point-at": {
+                                  "version": "1.0.1",
+                                  "from": "code-point-at@>=1.0.0 <2.0.0",
+                                  "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.0.1.tgz",
+                                  "dependencies": {
+                                    "number-is-nan": {
+                                      "version": "1.0.1",
+                                      "from": "number-is-nan@>=1.0.0 <2.0.0",
+                                      "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz"
+                                    }
+                                  }
+                                },
+                                "is-fullwidth-code-point": {
+                                  "version": "1.0.0",
+                                  "from": "is-fullwidth-code-point@>=1.0.0 <2.0.0",
+                                  "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+                                  "dependencies": {
+                                    "number-is-nan": {
+                                      "version": "1.0.1",
+                                      "from": "number-is-nan@>=1.0.0 <2.0.0",
+                                      "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz"
+                                    }
+                                  }
+                                }
+                              }
+                            },
+                            "strip-ansi": {
+                              "version": "3.0.1",
+                              "from": "strip-ansi@>=3.0.1 <4.0.0",
+                              "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+                              "dependencies": {
+                                "ansi-regex": {
+                                  "version": "2.0.0",
+                                  "from": "ansi-regex@>=2.0.0 <3.0.0",
+                                  "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
+                                }
+                              }
+                            },
+                            "wide-align": {
+                              "version": "1.1.0",
+                              "from": "wide-align@>=1.1.0 <2.0.0",
+                              "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.0.tgz"
+                            }
+                          }
+                        },
+                        "set-blocking": {
+                          "version": "2.0.0",
+                          "from": "set-blocking@>=2.0.0 <2.1.0",
+                          "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz"
+                        }
+                      }
+                    },
+                    "rc": {
+                      "version": "1.1.6",
+                      "from": "rc@>=1.1.0 <1.2.0",
+                      "resolved": "https://registry.npmjs.org/rc/-/rc-1.1.6.tgz",
+                      "dependencies": {
+                        "deep-extend": {
+                          "version": "0.4.1",
+                          "from": "deep-extend@>=0.4.0 <0.5.0",
+                          "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.4.1.tgz"
+                        },
+                        "ini": {
+                          "version": "1.3.4",
+                          "from": "ini@>=1.3.0 <1.4.0",
+                          "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.4.tgz"
+                        },
+                        "minimist": {
+                          "version": "1.2.0",
+                          "from": "minimist@>=1.2.0 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz"
+                        },
+                        "strip-json-comments": {
+                          "version": "1.0.4",
+                          "from": "strip-json-comments@>=1.0.4 <1.1.0",
+                          "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-1.0.4.tgz"
+                        }
+                      }
+                    },
+                    "rimraf": {
+                      "version": "2.5.4",
+                      "from": "rimraf@>=2.5.0 <2.6.0",
+                      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.5.4.tgz",
+                      "dependencies": {
+                        "glob": {
+                          "version": "7.1.1",
+                          "from": "glob@>=7.0.5 <8.0.0",
+                          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.1.tgz",
+                          "dependencies": {
+                            "fs.realpath": {
+                              "version": "1.0.0",
+                              "from": "fs.realpath@>=1.0.0 <2.0.0",
+                              "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz"
+                            },
+                            "inflight": {
+                              "version": "1.0.5",
+                              "from": "inflight@>=1.0.4 <2.0.0",
+                              "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.5.tgz",
+                              "dependencies": {
+                                "wrappy": {
+                                  "version": "1.0.2",
+                                  "from": "wrappy@>=1.0.0 <2.0.0",
+                                  "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz"
+                                }
+                              }
+                            },
+                            "inherits": {
+                              "version": "2.0.3",
+                              "from": "inherits@>=2.0.0 <3.0.0",
+                              "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz"
+                            },
+                            "minimatch": {
+                              "version": "3.0.3",
+                              "from": "minimatch@>=3.0.2 <4.0.0",
+                              "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.3.tgz",
+                              "dependencies": {
+                                "brace-expansion": {
+                                  "version": "1.1.6",
+                                  "from": "brace-expansion@>=1.0.0 <2.0.0",
+                                  "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.6.tgz",
+                                  "dependencies": {
+                                    "balanced-match": {
+                                      "version": "0.4.2",
+                                      "from": "balanced-match@>=0.4.1 <0.5.0",
+                                      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.4.2.tgz"
+                                    },
+                                    "concat-map": {
+                                      "version": "0.0.1",
+                                      "from": "concat-map@0.0.1",
+                                      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
+                                    }
+                                  }
+                                }
+                              }
+                            },
+                            "once": {
+                              "version": "1.4.0",
+                              "from": "once@>=1.3.0 <2.0.0",
+                              "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+                              "dependencies": {
+                                "wrappy": {
+                                  "version": "1.0.2",
+                                  "from": "wrappy@>=1.0.0 <2.0.0",
+                                  "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz"
+                                }
+                              }
+                            },
+                            "path-is-absolute": {
+                              "version": "1.0.1",
+                              "from": "path-is-absolute@>=1.0.0 <2.0.0",
+                              "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz"
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "semver": {
+                      "version": "5.3.0",
+                      "from": "semver@>=5.3.0 <5.4.0",
+                      "resolved": "https://registry.npmjs.org/semver/-/semver-5.3.0.tgz"
+                    },
+                    "tar": {
+                      "version": "2.2.1",
+                      "from": "tar@>=2.2.0 <2.3.0",
+                      "resolved": "https://registry.npmjs.org/tar/-/tar-2.2.1.tgz",
+                      "dependencies": {
+                        "block-stream": {
+                          "version": "0.0.9",
+                          "from": "block-stream@*",
+                          "resolved": "https://registry.npmjs.org/block-stream/-/block-stream-0.0.9.tgz"
+                        },
+                        "fstream": {
+                          "version": "1.0.10",
+                          "from": "fstream@>=1.0.10 <1.1.0",
+                          "resolved": "https://registry.npmjs.org/fstream/-/fstream-1.0.10.tgz",
+                          "dependencies": {
+                            "graceful-fs": {
+                              "version": "4.1.9",
+                              "from": "graceful-fs@>=4.1.2 <5.0.0",
+                              "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.9.tgz"
+                            }
+                          }
+                        },
+                        "inherits": {
+                          "version": "2.0.3",
+                          "from": "inherits@>=2.0.0 <3.0.0",
+                          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz"
+                        }
+                      }
+                    },
+                    "tar-pack": {
+                      "version": "3.1.4",
+                      "from": "tar-pack@>=3.1.0 <3.2.0",
+                      "resolved": "https://registry.npmjs.org/tar-pack/-/tar-pack-3.1.4.tgz",
+                      "dependencies": {
+                        "debug": {
+                          "version": "2.2.0",
+                          "from": "debug@>=2.2.0 <2.3.0",
+                          "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
+                          "dependencies": {
+                            "ms": {
+                              "version": "0.7.1",
+                              "from": "ms@0.7.1",
+                              "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz"
+                            }
+                          }
+                        },
+                        "fstream": {
+                          "version": "1.0.10",
+                          "from": "fstream@>=1.0.10 <1.1.0",
+                          "resolved": "https://registry.npmjs.org/fstream/-/fstream-1.0.10.tgz",
+                          "dependencies": {
+                            "graceful-fs": {
+                              "version": "4.1.9",
+                              "from": "graceful-fs@>=4.1.2 <5.0.0",
+                              "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.9.tgz"
+                            },
+                            "inherits": {
+                              "version": "2.0.3",
+                              "from": "inherits@>=2.0.0 <2.1.0",
+                              "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz"
+                            }
+                          }
+                        },
+                        "fstream-ignore": {
+                          "version": "1.0.5",
+                          "from": "fstream-ignore@>=1.0.5 <1.1.0",
+                          "resolved": "https://registry.npmjs.org/fstream-ignore/-/fstream-ignore-1.0.5.tgz",
+                          "dependencies": {
+                            "inherits": {
+                              "version": "2.0.3",
+                              "from": "inherits@>=2.0.0 <3.0.0",
+                              "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz"
+                            },
+                            "minimatch": {
+                              "version": "3.0.3",
+                              "from": "minimatch@>=3.0.0 <4.0.0",
+                              "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.3.tgz",
+                              "dependencies": {
+                                "brace-expansion": {
+                                  "version": "1.1.6",
+                                  "from": "brace-expansion@>=1.0.0 <2.0.0",
+                                  "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.6.tgz",
+                                  "dependencies": {
+                                    "balanced-match": {
+                                      "version": "0.4.2",
+                                      "from": "balanced-match@>=0.4.1 <0.5.0",
+                                      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.4.2.tgz"
+                                    },
+                                    "concat-map": {
+                                      "version": "0.0.1",
+                                      "from": "concat-map@0.0.1",
+                                      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
+                                    }
+                                  }
+                                }
+                              }
+                            }
+                          }
+                        },
+                        "once": {
+                          "version": "1.3.3",
+                          "from": "once@>=1.3.3 <1.4.0",
+                          "resolved": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
+                          "dependencies": {
+                            "wrappy": {
+                              "version": "1.0.2",
+                              "from": "wrappy@>=1.0.0 <2.0.0",
+                              "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz"
+                            }
+                          }
+                        },
+                        "readable-stream": {
+                          "version": "2.1.5",
+                          "from": "readable-stream@>=2.1.4 <2.2.0",
+                          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.1.5.tgz",
+                          "dependencies": {
+                            "buffer-shims": {
+                              "version": "1.0.0",
+                              "from": "buffer-shims@>=1.0.0 <2.0.0",
+                              "resolved": "https://registry.npmjs.org/buffer-shims/-/buffer-shims-1.0.0.tgz"
+                            },
+                            "core-util-is": {
+                              "version": "1.0.2",
+                              "from": "core-util-is@>=1.0.0 <1.1.0",
+                              "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
+                            },
+                            "inherits": {
+                              "version": "2.0.3",
+                              "from": "inherits@>=2.0.1 <2.1.0",
+                              "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz"
+                            },
+                            "isarray": {
+                              "version": "1.0.0",
+                              "from": "isarray@>=1.0.0 <1.1.0",
+                              "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz"
+                            },
+                            "process-nextick-args": {
+                              "version": "1.0.7",
+                              "from": "process-nextick-args@>=1.0.6 <1.1.0",
+                              "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz"
+                            },
+                            "string_decoder": {
+                              "version": "0.10.31",
+                              "from": "string_decoder@>=0.10.0 <0.11.0",
+                              "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+                            },
+                            "util-deprecate": {
+                              "version": "1.0.2",
+                              "from": "util-deprecate@>=1.0.1 <1.1.0",
+                              "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz"
+                            }
+                          }
+                        },
+                        "uid-number": {
+                          "version": "0.0.6",
+                          "from": "uid-number@>=0.0.6 <0.1.0",
+                          "resolved": "https://registry.npmjs.org/uid-number/-/uid-number-0.0.6.tgz"
+                        }
+                      }
+                    }
+                  }
                 }
               }
             }
           }
         },
-        "async": {
-          "version": "0.2.9",
-          "from": "async@0.2.9",
-          "resolved": "https://registry.npmjs.org/async/-/async-0.2.9.tgz"
-        },
         "dbug": {
-          "version": "0.4.1",
-          "from": "dbug@0.4.1",
-          "resolved": "https://registry.npmjs.org/dbug/-/dbug-0.4.1.tgz"
-        },
-        "optimist": {
-          "version": "0.6.0",
-          "from": "optimist@0.6.0",
-          "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.0.tgz",
-          "dependencies": {
-            "wordwrap": {
-              "version": "0.0.3",
-              "from": "wordwrap@>=0.0.2 <0.1.0",
-              "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz"
-            },
-            "minimist": {
-              "version": "0.0.10",
-              "from": "minimist@>=0.0.1 <0.1.0",
-              "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz"
-            }
-          }
+          "version": "0.4.2",
+          "from": "dbug@0.4.2",
+          "resolved": "https://registry.npmjs.org/dbug/-/dbug-0.4.2.tgz"
         },
         "colors": {
-          "version": "0.6.2",
-          "from": "colors@>=0.6.0-1 <0.7.0",
-          "resolved": "https://registry.npmjs.org/colors/-/colors-0.6.2.tgz"
-        },
-        "underscore": {
-          "version": "1.5.2",
-          "from": "underscore@>=1.5.2 <1.6.0",
-          "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.5.2.tgz"
+          "version": "1.1.2",
+          "from": "colors@1.1.2",
+          "resolved": "https://registry.npmjs.org/colors/-/colors-1.1.2.tgz"
         }
       }
     },
@@ -1406,62 +1962,58 @@
       }
     },
     "convict": {
-      "version": "1.1.2",
-      "from": "convict@1.1.2",
-      "resolved": "https://registry.npmjs.org/convict/-/convict-1.1.2.tgz",
+      "version": "1.5.0",
+      "from": "convict@1.5.0",
+      "resolved": "https://registry.npmjs.org/convict/-/convict-1.5.0.tgz",
       "dependencies": {
-        "cjson": {
-          "version": "0.3.3",
-          "from": "cjson@0.3.3",
-          "resolved": "https://registry.npmjs.org/cjson/-/cjson-0.3.3.tgz",
-          "dependencies": {
-            "json-parse-helpfulerror": {
-              "version": "1.0.3",
-              "from": "json-parse-helpfulerror@>=1.0.3 <2.0.0",
-              "resolved": "https://registry.npmjs.org/json-parse-helpfulerror/-/json-parse-helpfulerror-1.0.3.tgz",
-              "dependencies": {
-                "jju": {
-                  "version": "1.3.0",
-                  "from": "jju@>=1.1.0 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/jju/-/jju-1.3.0.tgz"
-                }
-              }
-            }
-          }
-        },
         "depd": {
           "version": "1.1.0",
-          "from": "depd@1.1.0",
+          "from": "https://registry.npmjs.org/depd/-/depd-1.1.0.tgz",
           "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.0.tgz"
         },
+        "json5": {
+          "version": "0.5.0",
+          "from": "https://registry.npmjs.org/json5/-/json5-0.5.0.tgz",
+          "resolved": "https://registry.npmjs.org/json5/-/json5-0.5.0.tgz"
+        },
+        "lodash": {
+          "version": "4.16.2",
+          "from": "https://registry.npmjs.org/lodash/-/lodash-4.16.2.tgz",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.16.2.tgz"
+        },
+        "minimist": {
+          "version": "1.2.0",
+          "from": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz"
+        },
         "moment": {
-          "version": "2.11.2",
-          "from": "moment@2.11.2",
-          "resolved": "https://registry.npmjs.org/moment/-/moment-2.11.2.tgz"
+          "version": "2.12.0",
+          "from": "https://registry.npmjs.org/moment/-/moment-2.12.0.tgz",
+          "resolved": "https://registry.npmjs.org/moment/-/moment-2.12.0.tgz"
         },
         "validator": {
           "version": "4.6.1",
-          "from": "validator@4.6.1",
+          "from": "https://registry.npmjs.org/validator/-/validator-4.6.1.tgz",
           "resolved": "https://registry.npmjs.org/validator/-/validator-4.6.1.tgz"
         },
         "varify": {
           "version": "0.1.1",
-          "from": "varify@0.1.1",
+          "from": "https://registry.npmjs.org/varify/-/varify-0.1.1.tgz",
           "resolved": "https://registry.npmjs.org/varify/-/varify-0.1.1.tgz",
           "dependencies": {
             "through": {
               "version": "2.3.8",
-              "from": "through@>=2.3.4 <2.4.0",
+              "from": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
               "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz"
             },
             "redeyed": {
               "version": "0.4.4",
-              "from": "redeyed@>=0.4.2 <0.5.0",
+              "from": "https://registry.npmjs.org/redeyed/-/redeyed-0.4.4.tgz",
               "resolved": "https://registry.npmjs.org/redeyed/-/redeyed-0.4.4.tgz",
               "dependencies": {
                 "esprima": {
                   "version": "1.0.4",
-                  "from": "esprima@>=1.0.2 <1.1.0",
+                  "from": "https://registry.npmjs.org/esprima/-/esprima-1.0.4.tgz",
                   "resolved": "https://registry.npmjs.org/esprima/-/esprima-1.0.4.tgz"
                 }
               }
@@ -1471,459 +2023,419 @@
       }
     },
     "express": {
-      "version": "3.8.1",
-      "from": "express@3.8.1",
-      "resolved": "https://registry.npmjs.org/express/-/express-3.8.1.tgz",
+      "version": "4.14.0",
+      "from": "express@4.14.0",
+      "resolved": "https://registry.npmjs.org/express/-/express-4.14.0.tgz",
       "dependencies": {
-        "connect": {
-          "version": "2.17.3",
-          "from": "connect@2.17.3",
-          "resolved": "https://registry.npmjs.org/connect/-/connect-2.17.3.tgz",
+        "accepts": {
+          "version": "1.3.3",
+          "from": "accepts@>=1.3.3 <1.4.0",
+          "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.3.tgz",
           "dependencies": {
-            "basic-auth-connect": {
-              "version": "1.0.0",
-              "from": "basic-auth-connect@1.0.0",
-              "resolved": "https://registry.npmjs.org/basic-auth-connect/-/basic-auth-connect-1.0.0.tgz"
-            },
-            "body-parser": {
-              "version": "1.2.2",
-              "from": "body-parser@1.2.2",
-              "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.2.2.tgz",
+            "mime-types": {
+              "version": "2.1.12",
+              "from": "mime-types@>=2.1.11 <2.2.0",
+              "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.12.tgz",
               "dependencies": {
-                "raw-body": {
-                  "version": "1.1.6",
-                  "from": "raw-body@1.1.6",
-                  "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-1.1.6.tgz"
+                "mime-db": {
+                  "version": "1.24.0",
+                  "from": "mime-db@>=1.24.0 <1.25.0",
+                  "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.24.0.tgz"
                 }
               }
             },
-            "bytes": {
-              "version": "1.0.0",
-              "from": "bytes@1.0.0",
-              "resolved": "https://registry.npmjs.org/bytes/-/bytes-1.0.0.tgz"
-            },
-            "cookie-parser": {
-              "version": "1.1.0",
-              "from": "cookie-parser@1.1.0",
-              "resolved": "https://registry.npmjs.org/cookie-parser/-/cookie-parser-1.1.0.tgz"
-            },
-            "compression": {
-              "version": "1.0.2",
-              "from": "compression@1.0.2",
-              "resolved": "https://registry.npmjs.org/compression/-/compression-1.0.2.tgz",
-              "dependencies": {
-                "bytes": {
-                  "version": "0.3.0",
-                  "from": "bytes@0.3.0",
-                  "resolved": "https://registry.npmjs.org/bytes/-/bytes-0.3.0.tgz"
-                },
-                "negotiator": {
-                  "version": "0.4.3",
-                  "from": "negotiator@0.4.3",
-                  "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.4.3.tgz"
-                },
-                "compressible": {
-                  "version": "1.0.1",
-                  "from": "compressible@1.0.1",
-                  "resolved": "https://registry.npmjs.org/compressible/-/compressible-1.0.1.tgz"
-                }
-              }
-            },
-            "connect-timeout": {
-              "version": "1.1.0",
-              "from": "connect-timeout@1.1.0",
-              "resolved": "https://registry.npmjs.org/connect-timeout/-/connect-timeout-1.1.0.tgz"
-            },
-            "csurf": {
-              "version": "1.2.0",
-              "from": "csurf@1.2.0",
-              "resolved": "https://registry.npmjs.org/csurf/-/csurf-1.2.0.tgz",
-              "dependencies": {
-                "uid2": {
-                  "version": "0.0.3",
-                  "from": "uid2@>=0.0.2 <0.1.0",
-                  "resolved": "https://registry.npmjs.org/uid2/-/uid2-0.0.3.tgz"
-                },
-                "scmp": {
-                  "version": "0.0.3",
-                  "from": "scmp@>=0.0.3 <0.1.0",
-                  "resolved": "https://registry.npmjs.org/scmp/-/scmp-0.0.3.tgz"
-                }
-              }
-            },
-            "errorhandler": {
-              "version": "1.0.1",
-              "from": "errorhandler@1.0.1",
-              "resolved": "https://registry.npmjs.org/errorhandler/-/errorhandler-1.0.1.tgz"
-            },
-            "express-session": {
-              "version": "1.2.1",
-              "from": "express-session@1.2.1",
-              "resolved": "https://registry.npmjs.org/express-session/-/express-session-1.2.1.tgz",
-              "dependencies": {
-                "utils-merge": {
-                  "version": "1.0.0",
-                  "from": "utils-merge@1.0.0",
-                  "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.0.tgz"
-                },
-                "uid2": {
-                  "version": "0.0.3",
-                  "from": "uid2@>=0.0.2 <0.1.0",
-                  "resolved": "https://registry.npmjs.org/uid2/-/uid2-0.0.3.tgz"
-                }
-              }
-            },
-            "method-override": {
-              "version": "1.0.2",
-              "from": "method-override@1.0.2",
-              "resolved": "https://registry.npmjs.org/method-override/-/method-override-1.0.2.tgz"
-            },
-            "morgan": {
-              "version": "1.1.1",
-              "from": "morgan@1.1.1",
-              "resolved": "https://registry.npmjs.org/morgan/-/morgan-1.1.1.tgz"
-            },
-            "on-headers": {
-              "version": "0.0.0",
-              "from": "on-headers@0.0.0",
-              "resolved": "https://registry.npmjs.org/on-headers/-/on-headers-0.0.0.tgz"
-            },
-            "qs": {
-              "version": "0.6.6",
-              "from": "qs@0.6.6",
-              "resolved": "https://registry.npmjs.org/qs/-/qs-0.6.6.tgz"
-            },
-            "response-time": {
-              "version": "1.0.0",
-              "from": "response-time@1.0.0",
-              "resolved": "https://registry.npmjs.org/response-time/-/response-time-1.0.0.tgz"
-            },
-            "serve-favicon": {
-              "version": "2.0.0",
-              "from": "serve-favicon@2.0.0",
-              "resolved": "https://registry.npmjs.org/serve-favicon/-/serve-favicon-2.0.0.tgz"
-            },
-            "serve-index": {
-              "version": "1.0.3",
-              "from": "serve-index@1.0.3",
-              "resolved": "https://registry.npmjs.org/serve-index/-/serve-index-1.0.3.tgz",
-              "dependencies": {
-                "batch": {
-                  "version": "0.5.0",
-                  "from": "batch@0.5.0",
-                  "resolved": "https://registry.npmjs.org/batch/-/batch-0.5.0.tgz"
-                },
-                "negotiator": {
-                  "version": "0.4.3",
-                  "from": "negotiator@0.4.3",
-                  "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.4.3.tgz"
-                }
-              }
-            },
-            "serve-static": {
-              "version": "1.1.0",
-              "from": "serve-static@1.1.0",
-              "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.1.0.tgz"
-            },
-            "type-is": {
-              "version": "1.2.0",
-              "from": "type-is@1.2.0",
-              "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.2.0.tgz",
-              "dependencies": {
-                "mime": {
-                  "version": "1.2.11",
-                  "from": "mime@1.2.11",
-                  "resolved": "https://registry.npmjs.org/mime/-/mime-1.2.11.tgz"
-                }
-              }
-            },
-            "vhost": {
-              "version": "1.0.0",
-              "from": "vhost@1.0.0",
-              "resolved": "https://registry.npmjs.org/vhost/-/vhost-1.0.0.tgz"
-            },
-            "pause": {
-              "version": "0.0.1",
-              "from": "pause@0.0.1",
-              "resolved": "https://registry.npmjs.org/pause/-/pause-0.0.1.tgz"
-            },
-            "multiparty": {
-              "version": "2.2.0",
-              "from": "multiparty@2.2.0",
-              "resolved": "https://registry.npmjs.org/multiparty/-/multiparty-2.2.0.tgz",
-              "dependencies": {
-                "readable-stream": {
-                  "version": "1.1.13",
-                  "from": "readable-stream@>=1.1.9 <1.2.0",
-                  "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz",
-                  "dependencies": {
-                    "core-util-is": {
-                      "version": "1.0.2",
-                      "from": "core-util-is@>=1.0.0 <1.1.0",
-                      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
-                    },
-                    "isarray": {
-                      "version": "0.0.1",
-                      "from": "isarray@0.0.1",
-                      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
-                    },
-                    "string_decoder": {
-                      "version": "0.10.31",
-                      "from": "string_decoder@>=0.10.0 <0.11.0",
-                      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
-                    },
-                    "inherits": {
-                      "version": "2.0.1",
-                      "from": "inherits@>=2.0.1 <2.1.0",
-                      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
-                    }
-                  }
-                },
-                "stream-counter": {
-                  "version": "0.2.0",
-                  "from": "stream-counter@>=0.2.0 <0.3.0",
-                  "resolved": "https://registry.npmjs.org/stream-counter/-/stream-counter-0.2.0.tgz"
-                }
-              }
+            "negotiator": {
+              "version": "0.6.1",
+              "from": "negotiator@0.6.1",
+              "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.1.tgz"
             }
           }
         },
-        "commander": {
-          "version": "1.3.2",
-          "from": "commander@1.3.2",
-          "resolved": "https://registry.npmjs.org/commander/-/commander-1.3.2.tgz",
+        "array-flatten": {
+          "version": "1.1.1",
+          "from": "array-flatten@1.1.1",
+          "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz"
+        },
+        "content-disposition": {
+          "version": "0.5.1",
+          "from": "content-disposition@0.5.1",
+          "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.1.tgz"
+        },
+        "content-type": {
+          "version": "1.0.2",
+          "from": "content-type@>=1.0.2 <1.1.0",
+          "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.2.tgz"
+        },
+        "cookie": {
+          "version": "0.3.1",
+          "from": "cookie@0.3.1",
+          "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.3.1.tgz"
+        },
+        "cookie-signature": {
+          "version": "1.0.6",
+          "from": "cookie-signature@1.0.6",
+          "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz"
+        },
+        "debug": {
+          "version": "2.2.0",
+          "from": "debug@>=2.2.0 <2.3.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
           "dependencies": {
-            "keypress": {
-              "version": "0.1.0",
-              "from": "keypress@>=0.1.0 <0.2.0",
-              "resolved": "https://registry.npmjs.org/keypress/-/keypress-0.1.0.tgz"
+            "ms": {
+              "version": "0.7.1",
+              "from": "ms@0.7.1",
+              "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz"
             }
           }
+        },
+        "depd": {
+          "version": "1.1.0",
+          "from": "depd@>=1.1.0 <1.2.0",
+          "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.0.tgz"
+        },
+        "encodeurl": {
+          "version": "1.0.1",
+          "from": "encodeurl@>=1.0.1 <1.1.0",
+          "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.1.tgz"
+        },
+        "escape-html": {
+          "version": "1.0.3",
+          "from": "escape-html@>=1.0.3 <1.1.0",
+          "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz"
+        },
+        "etag": {
+          "version": "1.7.0",
+          "from": "etag@>=1.7.0 <1.8.0",
+          "resolved": "https://registry.npmjs.org/etag/-/etag-1.7.0.tgz"
+        },
+        "finalhandler": {
+          "version": "0.5.0",
+          "from": "finalhandler@0.5.0",
+          "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-0.5.0.tgz",
+          "dependencies": {
+            "statuses": {
+              "version": "1.3.0",
+              "from": "statuses@>=1.3.0 <1.4.0",
+              "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.3.0.tgz"
+            },
+            "unpipe": {
+              "version": "1.0.0",
+              "from": "unpipe@>=1.0.0 <1.1.0",
+              "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz"
+            }
+          }
+        },
+        "fresh": {
+          "version": "0.3.0",
+          "from": "fresh@0.3.0",
+          "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.3.0.tgz"
+        },
+        "merge-descriptors": {
+          "version": "1.0.1",
+          "from": "merge-descriptors@1.0.1",
+          "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.1.tgz"
         },
         "methods": {
-          "version": "1.0.0",
-          "from": "methods@1.0.0",
-          "resolved": "https://registry.npmjs.org/methods/-/methods-1.0.0.tgz"
+          "version": "1.1.2",
+          "from": "methods@>=1.1.2 <1.2.0",
+          "resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz"
         },
-        "mkdirp": {
-          "version": "0.5.0",
-          "from": "mkdirp@0.5.0",
-          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.0.tgz",
+        "on-finished": {
+          "version": "2.3.0",
+          "from": "on-finished@>=2.3.0 <2.4.0",
+          "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.3.0.tgz",
           "dependencies": {
-            "minimist": {
-              "version": "0.0.8",
-              "from": "minimist@0.0.8",
-              "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
+            "ee-first": {
+              "version": "1.1.1",
+              "from": "ee-first@1.1.1",
+              "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz"
             }
           }
         },
         "parseurl": {
-          "version": "1.0.1",
-          "from": "parseurl@1.0.1",
-          "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.0.1.tgz"
+          "version": "1.3.1",
+          "from": "parseurl@>=1.3.1 <1.4.0",
+          "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.1.tgz"
+        },
+        "path-to-regexp": {
+          "version": "0.1.7",
+          "from": "path-to-regexp@0.1.7",
+          "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.7.tgz"
         },
         "proxy-addr": {
-          "version": "1.0.0",
-          "from": "proxy-addr@1.0.0",
-          "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-1.0.0.tgz",
+          "version": "1.1.2",
+          "from": "proxy-addr@>=1.1.2 <1.2.0",
+          "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-1.1.2.tgz",
           "dependencies": {
+            "forwarded": {
+              "version": "0.1.0",
+              "from": "forwarded@>=0.1.0 <0.2.0",
+              "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.1.0.tgz"
+            },
             "ipaddr.js": {
-              "version": "0.1.2",
-              "from": "ipaddr.js@0.1.2",
-              "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-0.1.2.tgz"
+              "version": "1.1.1",
+              "from": "ipaddr.js@1.1.1",
+              "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.1.1.tgz"
             }
           }
+        },
+        "qs": {
+          "version": "6.2.0",
+          "from": "qs@6.2.0",
+          "resolved": "https://registry.npmjs.org/qs/-/qs-6.2.0.tgz"
         },
         "range-parser": {
-          "version": "1.0.0",
-          "from": "range-parser@1.0.0",
-          "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.0.0.tgz"
-        },
-        "cookie": {
-          "version": "0.1.2",
-          "from": "cookie@0.1.2",
-          "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.1.2.tgz"
-        },
-        "buffer-crc32": {
-          "version": "0.2.1",
-          "from": "buffer-crc32@0.2.1",
-          "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.1.tgz"
-        },
-        "fresh": {
-          "version": "0.2.2",
-          "from": "fresh@0.2.2",
-          "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.2.2.tgz"
+          "version": "1.2.0",
+          "from": "range-parser@>=1.2.0 <1.3.0",
+          "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.0.tgz"
         },
         "send": {
-          "version": "0.3.0",
-          "from": "send@0.3.0",
-          "resolved": "https://registry.npmjs.org/send/-/send-0.3.0.tgz",
+          "version": "0.14.1",
+          "from": "send@0.14.1",
+          "resolved": "https://registry.npmjs.org/send/-/send-0.14.1.tgz",
           "dependencies": {
-            "debug": {
-              "version": "0.8.0",
-              "from": "debug@0.8.0",
-              "resolved": "https://registry.npmjs.org/debug/-/debug-0.8.0.tgz"
+            "destroy": {
+              "version": "1.0.4",
+              "from": "destroy@>=1.0.4 <1.1.0",
+              "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.0.4.tgz"
+            },
+            "http-errors": {
+              "version": "1.5.0",
+              "from": "http-errors@>=1.5.0 <1.6.0",
+              "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.5.0.tgz",
+              "dependencies": {
+                "inherits": {
+                  "version": "2.0.1",
+                  "from": "inherits@2.0.1",
+                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                },
+                "setprototypeof": {
+                  "version": "1.0.1",
+                  "from": "setprototypeof@1.0.1",
+                  "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.0.1.tgz"
+                }
+              }
             },
             "mime": {
-              "version": "1.2.11",
-              "from": "mime@1.2.11",
-              "resolved": "https://registry.npmjs.org/mime/-/mime-1.2.11.tgz"
+              "version": "1.3.4",
+              "from": "mime@1.3.4",
+              "resolved": "https://registry.npmjs.org/mime/-/mime-1.3.4.tgz"
+            },
+            "ms": {
+              "version": "0.7.1",
+              "from": "ms@0.7.1",
+              "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz"
+            },
+            "statuses": {
+              "version": "1.3.0",
+              "from": "statuses@>=1.3.0 <1.4.0",
+              "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.3.0.tgz"
             }
           }
         },
-        "cookie-signature": {
-          "version": "1.0.3",
-          "from": "cookie-signature@1.0.3",
-          "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.3.tgz"
+        "serve-static": {
+          "version": "1.11.1",
+          "from": "serve-static@>=1.11.1 <1.12.0",
+          "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.11.1.tgz"
         },
-        "merge-descriptors": {
-          "version": "0.0.2",
-          "from": "merge-descriptors@0.0.2",
-          "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-0.0.2.tgz"
+        "type-is": {
+          "version": "1.6.13",
+          "from": "type-is@>=1.6.13 <1.7.0",
+          "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.13.tgz",
+          "dependencies": {
+            "media-typer": {
+              "version": "0.3.0",
+              "from": "media-typer@0.3.0",
+              "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz"
+            },
+            "mime-types": {
+              "version": "2.1.12",
+              "from": "mime-types@>=2.1.11 <2.2.0",
+              "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.12.tgz",
+              "dependencies": {
+                "mime-db": {
+                  "version": "1.24.0",
+                  "from": "mime-db@>=1.24.0 <1.25.0",
+                  "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.24.0.tgz"
+                }
+              }
+            }
+          }
         },
-        "debug": {
-          "version": "0.8.1",
-          "from": "debug@>=0.8.0 <1.0.0",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-0.8.1.tgz"
+        "utils-merge": {
+          "version": "1.0.0",
+          "from": "utils-merge@1.0.0",
+          "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.0.tgz"
+        },
+        "vary": {
+          "version": "1.1.0",
+          "from": "vary@>=1.1.0 <1.2.0",
+          "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.0.tgz"
         }
       }
     },
     "intel": {
-      "version": "0.5.2",
-      "from": "intel@0.5.2",
-      "resolved": "https://registry.npmjs.org/intel/-/intel-0.5.2.tgz",
+      "version": "1.1.1",
+      "from": "intel@1.1.1",
+      "resolved": "https://registry.npmjs.org/intel/-/intel-1.1.1.tgz",
       "dependencies": {
-        "bluebird": {
-          "version": "1.0.8",
-          "from": "bluebird@>=1.0.0 <1.1.0",
-          "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-1.0.8.tgz"
-        },
         "chalk": {
-          "version": "0.4.0",
-          "from": "chalk@0.4.0",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-0.4.0.tgz",
+          "version": "1.1.3",
+          "from": "chalk@>=1.1.0 <1.2.0",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
           "dependencies": {
-            "has-color": {
-              "version": "0.1.7",
-              "from": "has-color@>=0.1.0 <0.2.0",
-              "resolved": "https://registry.npmjs.org/has-color/-/has-color-0.1.7.tgz"
-            },
             "ansi-styles": {
-              "version": "1.0.0",
-              "from": "ansi-styles@>=1.0.0 <1.1.0",
-              "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-1.0.0.tgz"
+              "version": "2.2.1",
+              "from": "ansi-styles@>=2.2.1 <3.0.0",
+              "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz"
+            },
+            "escape-string-regexp": {
+              "version": "1.0.5",
+              "from": "escape-string-regexp@>=1.0.2 <2.0.0",
+              "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz"
+            },
+            "has-ansi": {
+              "version": "2.0.0",
+              "from": "has-ansi@>=2.0.0 <3.0.0",
+              "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
+              "dependencies": {
+                "ansi-regex": {
+                  "version": "2.0.0",
+                  "from": "ansi-regex@>=2.0.0 <3.0.0",
+                  "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
+                }
+              }
             },
             "strip-ansi": {
-              "version": "0.1.1",
-              "from": "strip-ansi@>=0.1.0 <0.2.0",
-              "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-0.1.1.tgz"
+              "version": "3.0.1",
+              "from": "strip-ansi@>=3.0.0 <4.0.0",
+              "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+              "dependencies": {
+                "ansi-regex": {
+                  "version": "2.0.0",
+                  "from": "ansi-regex@>=2.0.0 <3.0.0",
+                  "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
+                }
+              }
+            },
+            "supports-color": {
+              "version": "2.0.0",
+              "from": "supports-color@>=2.0.0 <3.0.0",
+              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
             }
           }
         },
         "dbug": {
-          "version": "0.2.0",
-          "from": "dbug@>=0.2.0 <0.3.0",
-          "resolved": "https://registry.npmjs.org/dbug/-/dbug-0.2.0.tgz"
+          "version": "0.4.2",
+          "from": "dbug@>=0.4.2 <0.5.0",
+          "resolved": "https://registry.npmjs.org/dbug/-/dbug-0.4.2.tgz"
         },
         "stack-trace": {
-          "version": "0.0.8",
-          "from": "stack-trace@0.0.8",
-          "resolved": "https://registry.npmjs.org/stack-trace/-/stack-trace-0.0.8.tgz"
+          "version": "0.0.9",
+          "from": "stack-trace@>=0.0.9 <0.1.0",
+          "resolved": "https://registry.npmjs.org/stack-trace/-/stack-trace-0.0.9.tgz"
         },
         "strftime": {
-          "version": "0.8.0",
-          "from": "strftime@0.8.0",
-          "resolved": "https://registry.npmjs.org/strftime/-/strftime-0.8.0.tgz"
+          "version": "0.9.2",
+          "from": "strftime@>=0.9.2 <0.10.0",
+          "resolved": "https://registry.npmjs.org/strftime/-/strftime-0.9.2.tgz"
         },
         "symbol": {
-          "version": "0.1.0",
-          "from": "symbol@0.1.0",
-          "resolved": "https://registry.npmjs.org/symbol/-/symbol-0.1.0.tgz"
+          "version": "0.3.0",
+          "from": "symbol@>=0.3.0 <0.4.0",
+          "resolved": "https://registry.npmjs.org/symbol/-/symbol-0.3.0.tgz"
         },
         "utcstring": {
           "version": "0.1.0",
-          "from": "utcstring@0.1.0",
+          "from": "utcstring@>=0.1.0 <0.2.0",
           "resolved": "https://registry.npmjs.org/utcstring/-/utcstring-0.1.0.tgz"
         }
       }
     },
     "jshint": {
-      "version": "2.5.1",
-      "from": "jshint@2.5.1",
-      "resolved": "https://registry.npmjs.org/jshint/-/jshint-2.5.1.tgz",
+      "version": "2.9.3",
+      "from": "jshint@2.9.3",
+      "resolved": "https://registry.npmjs.org/jshint/-/jshint-2.9.3.tgz",
       "dependencies": {
-        "shelljs": {
-          "version": "0.3.0",
-          "from": "shelljs@>=0.3.0 <0.4.0",
-          "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.3.0.tgz"
-        },
-        "underscore": {
-          "version": "1.6.0",
-          "from": "underscore@>=1.6.0 <1.7.0",
-          "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.6.0.tgz"
-        },
         "cli": {
-          "version": "0.6.6",
-          "from": "cli@>=0.6.0 <0.7.0",
-          "resolved": "https://registry.npmjs.org/cli/-/cli-0.6.6.tgz",
+          "version": "1.0.0",
+          "from": "cli@>=1.0.0 <1.1.0",
+          "resolved": "https://registry.npmjs.org/cli/-/cli-1.0.0.tgz",
           "dependencies": {
             "glob": {
-              "version": "3.2.11",
-              "from": "glob@>=3.2.1 <3.3.0",
-              "resolved": "https://registry.npmjs.org/glob/-/glob-3.2.11.tgz",
+              "version": "7.1.1",
+              "from": "glob@>=7.0.5 <8.0.0",
+              "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.1.tgz",
               "dependencies": {
-                "inherits": {
-                  "version": "2.0.1",
-                  "from": "inherits@>=2.0.0 <3.0.0",
-                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                "fs.realpath": {
+                  "version": "1.0.0",
+                  "from": "fs.realpath@>=1.0.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz"
                 },
-                "minimatch": {
-                  "version": "0.3.0",
-                  "from": "minimatch@>=0.3.0 <0.4.0",
-                  "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.3.0.tgz",
+                "inflight": {
+                  "version": "1.0.5",
+                  "from": "inflight@>=1.0.4 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.5.tgz",
                   "dependencies": {
-                    "lru-cache": {
-                      "version": "2.7.3",
-                      "from": "lru-cache@>=2.0.0 <3.0.0",
-                      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.7.3.tgz"
-                    },
-                    "sigmund": {
-                      "version": "1.0.1",
-                      "from": "sigmund@>=1.0.0 <1.1.0",
-                      "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz"
+                    "wrappy": {
+                      "version": "1.0.2",
+                      "from": "wrappy@>=1.0.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz"
                     }
                   }
+                },
+                "inherits": {
+                  "version": "2.0.3",
+                  "from": "inherits@>=2.0.0 <3.0.0",
+                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz"
+                },
+                "once": {
+                  "version": "1.4.0",
+                  "from": "once@>=1.3.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+                  "dependencies": {
+                    "wrappy": {
+                      "version": "1.0.2",
+                      "from": "wrappy@>=1.0.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz"
+                    }
+                  }
+                },
+                "path-is-absolute": {
+                  "version": "1.0.1",
+                  "from": "path-is-absolute@>=1.0.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz"
                 }
               }
             }
           }
         },
-        "minimatch": {
-          "version": "0.4.0",
-          "from": "minimatch@>=0.0.0 <1.0.0",
-          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.4.0.tgz",
+        "console-browserify": {
+          "version": "1.1.0",
+          "from": "console-browserify@>=1.1.0 <1.2.0",
+          "resolved": "https://registry.npmjs.org/console-browserify/-/console-browserify-1.1.0.tgz",
           "dependencies": {
-            "lru-cache": {
-              "version": "2.7.3",
-              "from": "lru-cache@>=2.0.0 <3.0.0",
-              "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.7.3.tgz"
-            },
-            "sigmund": {
-              "version": "1.0.1",
-              "from": "sigmund@>=1.0.0 <1.1.0",
-              "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz"
+            "date-now": {
+              "version": "0.1.4",
+              "from": "date-now@>=0.1.4 <0.2.0",
+              "resolved": "https://registry.npmjs.org/date-now/-/date-now-0.1.4.tgz"
             }
           }
         },
+        "exit": {
+          "version": "0.1.2",
+          "from": "exit@>=0.1.0 <0.2.0",
+          "resolved": "https://registry.npmjs.org/exit/-/exit-0.1.2.tgz"
+        },
         "htmlparser2": {
-          "version": "3.7.3",
-          "from": "htmlparser2@>=3.7.0 <3.8.0",
-          "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-3.7.3.tgz",
+          "version": "3.8.3",
+          "from": "htmlparser2@>=3.8.0 <3.9.0",
+          "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-3.8.3.tgz",
           "dependencies": {
             "domhandler": {
-              "version": "2.2.1",
-              "from": "domhandler@>=2.2.0 <2.3.0",
-              "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-2.2.1.tgz"
+              "version": "2.3.0",
+              "from": "domhandler@>=2.3.0 <2.4.0",
+              "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-2.3.0.tgz"
             },
             "domutils": {
               "version": "1.5.1",
@@ -1955,9 +2467,9 @@
               "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.3.0.tgz"
             },
             "readable-stream": {
-              "version": "1.1.13",
+              "version": "1.1.14",
               "from": "readable-stream@>=1.1.0 <1.2.0",
-              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz",
+              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
               "dependencies": {
                 "core-util-is": {
                   "version": "1.0.2",
@@ -1975,9 +2487,9 @@
                   "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
                 },
                 "inherits": {
-                  "version": "2.0.1",
+                  "version": "2.0.3",
                   "from": "inherits@>=2.0.1 <2.1.0",
-                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz"
                 }
               }
             },
@@ -1988,70 +2500,72 @@
             }
           }
         },
-        "console-browserify": {
-          "version": "1.1.0",
-          "from": "console-browserify@>=1.1.0 <1.2.0",
-          "resolved": "https://registry.npmjs.org/console-browserify/-/console-browserify-1.1.0.tgz",
+        "minimatch": {
+          "version": "3.0.3",
+          "from": "minimatch@>=3.0.2 <3.1.0",
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.3.tgz",
           "dependencies": {
-            "date-now": {
-              "version": "0.1.4",
-              "from": "date-now@>=0.1.4 <0.2.0",
-              "resolved": "https://registry.npmjs.org/date-now/-/date-now-0.1.4.tgz"
+            "brace-expansion": {
+              "version": "1.1.6",
+              "from": "brace-expansion@>=1.0.0 <2.0.0",
+              "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.6.tgz",
+              "dependencies": {
+                "balanced-match": {
+                  "version": "0.4.2",
+                  "from": "balanced-match@>=0.4.1 <0.5.0",
+                  "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.4.2.tgz"
+                },
+                "concat-map": {
+                  "version": "0.0.1",
+                  "from": "concat-map@0.0.1",
+                  "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
+                }
+              }
             }
           }
         },
-        "exit": {
-          "version": "0.1.2",
-          "from": "exit@>=0.1.0 <0.2.0",
-          "resolved": "https://registry.npmjs.org/exit/-/exit-0.1.2.tgz"
+        "shelljs": {
+          "version": "0.3.0",
+          "from": "shelljs@>=0.3.0 <0.4.0",
+          "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.3.0.tgz"
         },
         "strip-json-comments": {
-          "version": "0.1.3",
-          "from": "strip-json-comments@>=0.1.0 <0.2.0",
-          "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-0.1.3.tgz"
+          "version": "1.0.4",
+          "from": "strip-json-comments@>=1.0.0 <1.1.0",
+          "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-1.0.4.tgz"
+        },
+        "lodash": {
+          "version": "3.7.0",
+          "from": "lodash@>=3.7.0 <3.8.0",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.7.0.tgz"
         }
       }
     },
     "mocha": {
-      "version": "1.20.0",
-      "from": "mocha@1.20.0",
-      "resolved": "https://registry.npmjs.org/mocha/-/mocha-1.20.0.tgz",
+      "version": "3.1.0",
+      "from": "mocha@3.1.0",
+      "resolved": "https://registry.npmjs.org/mocha/-/mocha-3.1.0.tgz",
       "dependencies": {
+        "browser-stdout": {
+          "version": "1.3.0",
+          "from": "browser-stdout@1.3.0",
+          "resolved": "https://registry.npmjs.org/browser-stdout/-/browser-stdout-1.3.0.tgz"
+        },
         "commander": {
-          "version": "2.0.0",
-          "from": "commander@2.0.0",
-          "resolved": "https://registry.npmjs.org/commander/-/commander-2.0.0.tgz"
-        },
-        "growl": {
-          "version": "1.7.0",
-          "from": "growl@>=1.7.0 <1.8.0",
-          "resolved": "https://registry.npmjs.org/growl/-/growl-1.7.0.tgz"
-        },
-        "jade": {
-          "version": "0.26.3",
-          "from": "jade@0.26.3",
-          "resolved": "https://registry.npmjs.org/jade/-/jade-0.26.3.tgz",
+          "version": "2.9.0",
+          "from": "commander@2.9.0",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz",
           "dependencies": {
-            "commander": {
-              "version": "0.6.1",
-              "from": "commander@0.6.1",
-              "resolved": "https://registry.npmjs.org/commander/-/commander-0.6.1.tgz"
-            },
-            "mkdirp": {
-              "version": "0.3.0",
-              "from": "mkdirp@0.3.0",
-              "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.3.0.tgz"
+            "graceful-readlink": {
+              "version": "1.0.1",
+              "from": "graceful-readlink@>=1.0.0",
+              "resolved": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz"
             }
           }
         },
-        "diff": {
-          "version": "1.0.7",
-          "from": "diff@1.0.7",
-          "resolved": "https://registry.npmjs.org/diff/-/diff-1.0.7.tgz"
-        },
         "debug": {
           "version": "2.2.0",
-          "from": "debug@*",
+          "from": "debug@2.2.0",
           "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
           "dependencies": {
             "ms": {
@@ -2061,44 +2575,216 @@
             }
           }
         },
-        "mkdirp": {
-          "version": "0.3.5",
-          "from": "mkdirp@0.3.5",
-          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.3.5.tgz"
+        "diff": {
+          "version": "1.4.0",
+          "from": "diff@1.4.0",
+          "resolved": "https://registry.npmjs.org/diff/-/diff-1.4.0.tgz"
+        },
+        "escape-string-regexp": {
+          "version": "1.0.5",
+          "from": "escape-string-regexp@1.0.5",
+          "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz"
         },
         "glob": {
-          "version": "3.2.3",
-          "from": "glob@3.2.3",
-          "resolved": "https://registry.npmjs.org/glob/-/glob-3.2.3.tgz",
+          "version": "7.0.5",
+          "from": "glob@7.0.5",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-7.0.5.tgz",
           "dependencies": {
-            "minimatch": {
-              "version": "0.2.14",
-              "from": "minimatch@>=0.2.11 <0.3.0",
-              "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.2.14.tgz",
+            "fs.realpath": {
+              "version": "1.0.0",
+              "from": "fs.realpath@>=1.0.0 <2.0.0",
+              "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz"
+            },
+            "inflight": {
+              "version": "1.0.5",
+              "from": "inflight@>=1.0.4 <2.0.0",
+              "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.5.tgz",
               "dependencies": {
-                "lru-cache": {
-                  "version": "2.7.3",
-                  "from": "lru-cache@>=2.0.0 <3.0.0",
-                  "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.7.3.tgz"
-                },
-                "sigmund": {
-                  "version": "1.0.1",
-                  "from": "sigmund@>=1.0.0 <1.1.0",
-                  "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz"
+                "wrappy": {
+                  "version": "1.0.2",
+                  "from": "wrappy@>=1.0.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz"
                 }
               }
             },
-            "graceful-fs": {
-              "version": "2.0.3",
-              "from": "graceful-fs@>=2.0.0 <2.1.0",
-              "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-2.0.3.tgz"
-            },
             "inherits": {
-              "version": "2.0.1",
+              "version": "2.0.3",
               "from": "inherits@>=2.0.0 <3.0.0",
-              "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+              "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz"
+            },
+            "minimatch": {
+              "version": "3.0.3",
+              "from": "minimatch@>=3.0.2 <4.0.0",
+              "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.3.tgz",
+              "dependencies": {
+                "brace-expansion": {
+                  "version": "1.1.6",
+                  "from": "brace-expansion@>=1.0.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.6.tgz",
+                  "dependencies": {
+                    "balanced-match": {
+                      "version": "0.4.2",
+                      "from": "balanced-match@>=0.4.1 <0.5.0",
+                      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.4.2.tgz"
+                    },
+                    "concat-map": {
+                      "version": "0.0.1",
+                      "from": "concat-map@0.0.1",
+                      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
+                    }
+                  }
+                }
+              }
+            },
+            "once": {
+              "version": "1.4.0",
+              "from": "once@>=1.3.0 <2.0.0",
+              "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+              "dependencies": {
+                "wrappy": {
+                  "version": "1.0.2",
+                  "from": "wrappy@>=1.0.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz"
+                }
+              }
+            },
+            "path-is-absolute": {
+              "version": "1.0.1",
+              "from": "path-is-absolute@>=1.0.0 <2.0.0",
+              "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz"
             }
           }
+        },
+        "growl": {
+          "version": "1.9.2",
+          "from": "growl@1.9.2",
+          "resolved": "https://registry.npmjs.org/growl/-/growl-1.9.2.tgz"
+        },
+        "json3": {
+          "version": "3.3.2",
+          "from": "json3@3.3.2",
+          "resolved": "https://registry.npmjs.org/json3/-/json3-3.3.2.tgz"
+        },
+        "lodash.create": {
+          "version": "3.1.1",
+          "from": "lodash.create@3.1.1",
+          "resolved": "https://registry.npmjs.org/lodash.create/-/lodash.create-3.1.1.tgz",
+          "dependencies": {
+            "lodash._baseassign": {
+              "version": "3.2.0",
+              "from": "lodash._baseassign@>=3.0.0 <4.0.0",
+              "resolved": "https://registry.npmjs.org/lodash._baseassign/-/lodash._baseassign-3.2.0.tgz",
+              "dependencies": {
+                "lodash._basecopy": {
+                  "version": "3.0.1",
+                  "from": "lodash._basecopy@>=3.0.0 <4.0.0",
+                  "resolved": "https://registry.npmjs.org/lodash._basecopy/-/lodash._basecopy-3.0.1.tgz"
+                },
+                "lodash.keys": {
+                  "version": "3.1.2",
+                  "from": "lodash.keys@>=3.0.0 <4.0.0",
+                  "resolved": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-3.1.2.tgz",
+                  "dependencies": {
+                    "lodash._getnative": {
+                      "version": "3.9.1",
+                      "from": "lodash._getnative@>=3.0.0 <4.0.0",
+                      "resolved": "https://registry.npmjs.org/lodash._getnative/-/lodash._getnative-3.9.1.tgz"
+                    },
+                    "lodash.isarguments": {
+                      "version": "3.1.0",
+                      "from": "lodash.isarguments@>=3.0.0 <4.0.0",
+                      "resolved": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.1.0.tgz"
+                    },
+                    "lodash.isarray": {
+                      "version": "3.0.4",
+                      "from": "lodash.isarray@>=3.0.0 <4.0.0",
+                      "resolved": "https://registry.npmjs.org/lodash.isarray/-/lodash.isarray-3.0.4.tgz"
+                    }
+                  }
+                }
+              }
+            },
+            "lodash._basecreate": {
+              "version": "3.0.3",
+              "from": "lodash._basecreate@>=3.0.0 <4.0.0",
+              "resolved": "https://registry.npmjs.org/lodash._basecreate/-/lodash._basecreate-3.0.3.tgz"
+            },
+            "lodash._isiterateecall": {
+              "version": "3.0.9",
+              "from": "lodash._isiterateecall@>=3.0.0 <4.0.0",
+              "resolved": "https://registry.npmjs.org/lodash._isiterateecall/-/lodash._isiterateecall-3.0.9.tgz"
+            }
+          }
+        },
+        "mkdirp": {
+          "version": "0.5.1",
+          "from": "mkdirp@0.5.1",
+          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+          "dependencies": {
+            "minimist": {
+              "version": "0.0.8",
+              "from": "minimist@0.0.8",
+              "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
+            }
+          }
+        },
+        "supports-color": {
+          "version": "3.1.2",
+          "from": "supports-color@3.1.2",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.1.2.tgz",
+          "dependencies": {
+            "has-flag": {
+              "version": "1.0.0",
+              "from": "has-flag@>=1.0.0 <2.0.0",
+              "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz"
+            }
+          }
+        }
+      }
+    },
+    "morgan": {
+      "version": "1.7.0",
+      "from": "morgan@>=1.7.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/morgan/-/morgan-1.7.0.tgz",
+      "dependencies": {
+        "basic-auth": {
+          "version": "1.0.4",
+          "from": "basic-auth@>=1.0.3 <1.1.0",
+          "resolved": "https://registry.npmjs.org/basic-auth/-/basic-auth-1.0.4.tgz"
+        },
+        "debug": {
+          "version": "2.2.0",
+          "from": "debug@>=2.2.0 <2.3.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
+          "dependencies": {
+            "ms": {
+              "version": "0.7.1",
+              "from": "ms@0.7.1",
+              "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz"
+            }
+          }
+        },
+        "depd": {
+          "version": "1.1.0",
+          "from": "depd@>=1.1.0 <1.2.0",
+          "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.0.tgz"
+        },
+        "on-finished": {
+          "version": "2.3.0",
+          "from": "on-finished@>=2.3.0 <2.4.0",
+          "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.3.0.tgz",
+          "dependencies": {
+            "ee-first": {
+              "version": "1.1.1",
+              "from": "ee-first@1.1.1",
+              "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz"
+            }
+          }
+        },
+        "on-headers": {
+          "version": "1.0.1",
+          "from": "on-headers@>=1.0.1 <1.1.0",
+          "resolved": "https://registry.npmjs.org/on-headers/-/on-headers-1.0.1.tgz"
         }
       }
     },
@@ -2120,135 +2806,428 @@
       }
     },
     "request": {
-      "version": "2.36.0",
-      "from": "request@2.36.0",
-      "resolved": "https://registry.npmjs.org/request/-/request-2.36.0.tgz",
+      "version": "2.75.0",
+      "from": "request@2.75.0",
+      "resolved": "https://registry.npmjs.org/request/-/request-2.75.0.tgz",
       "dependencies": {
-        "qs": {
-          "version": "0.6.6",
-          "from": "qs@>=0.6.0 <0.7.0",
-          "resolved": "https://registry.npmjs.org/qs/-/qs-0.6.6.tgz"
+        "aws-sign2": {
+          "version": "0.6.0",
+          "from": "aws-sign2@>=0.6.0 <0.7.0",
+          "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.6.0.tgz"
         },
-        "json-stringify-safe": {
-          "version": "5.0.1",
-          "from": "json-stringify-safe@>=5.0.0 <5.1.0",
-          "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz"
+        "aws4": {
+          "version": "1.4.1",
+          "from": "aws4@>=1.2.1 <2.0.0",
+          "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.4.1.tgz"
         },
-        "mime": {
-          "version": "1.2.11",
-          "from": "mime@>=1.2.9 <1.3.0",
-          "resolved": "https://registry.npmjs.org/mime/-/mime-1.2.11.tgz"
-        },
-        "forever-agent": {
-          "version": "0.5.2",
-          "from": "forever-agent@>=0.5.0 <0.6.0",
-          "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.5.2.tgz"
-        },
-        "node-uuid": {
-          "version": "1.4.7",
-          "from": "node-uuid@>=1.4.0 <1.5.0",
-          "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.7.tgz"
-        },
-        "tough-cookie": {
-          "version": "2.2.1",
-          "from": "tough-cookie@>=0.12.0",
-          "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.2.1.tgz"
-        },
-        "form-data": {
-          "version": "0.1.4",
-          "from": "form-data@>=0.1.0 <0.2.0",
-          "resolved": "https://registry.npmjs.org/form-data/-/form-data-0.1.4.tgz",
+        "bl": {
+          "version": "1.1.2",
+          "from": "bl@>=1.1.2 <1.2.0",
+          "resolved": "https://registry.npmjs.org/bl/-/bl-1.1.2.tgz",
           "dependencies": {
-            "combined-stream": {
-              "version": "0.0.7",
-              "from": "combined-stream@>=0.0.4 <0.1.0",
-              "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-0.0.7.tgz",
+            "readable-stream": {
+              "version": "2.0.6",
+              "from": "readable-stream@>=2.0.5 <2.1.0",
+              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.6.tgz",
               "dependencies": {
-                "delayed-stream": {
-                  "version": "0.0.5",
-                  "from": "delayed-stream@0.0.5",
-                  "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-0.0.5.tgz"
+                "core-util-is": {
+                  "version": "1.0.2",
+                  "from": "core-util-is@>=1.0.0 <1.1.0",
+                  "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
+                },
+                "inherits": {
+                  "version": "2.0.3",
+                  "from": "inherits@>=2.0.1 <2.1.0",
+                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz"
+                },
+                "isarray": {
+                  "version": "1.0.0",
+                  "from": "isarray@>=1.0.0 <1.1.0",
+                  "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz"
+                },
+                "process-nextick-args": {
+                  "version": "1.0.7",
+                  "from": "process-nextick-args@>=1.0.6 <1.1.0",
+                  "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz"
+                },
+                "string_decoder": {
+                  "version": "0.10.31",
+                  "from": "string_decoder@>=0.10.0 <0.11.0",
+                  "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+                },
+                "util-deprecate": {
+                  "version": "1.0.2",
+                  "from": "util-deprecate@>=1.0.1 <1.1.0",
+                  "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz"
                 }
               }
             }
           }
         },
-        "tunnel-agent": {
-          "version": "0.4.2",
-          "from": "tunnel-agent@>=0.4.0 <0.5.0",
-          "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.2.tgz"
+        "caseless": {
+          "version": "0.11.0",
+          "from": "caseless@>=0.11.0 <0.12.0",
+          "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.11.0.tgz"
         },
-        "http-signature": {
-          "version": "0.10.1",
-          "from": "http-signature@>=0.10.0 <0.11.0",
-          "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-0.10.1.tgz",
+        "combined-stream": {
+          "version": "1.0.5",
+          "from": "combined-stream@>=1.0.5 <1.1.0",
+          "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz",
           "dependencies": {
-            "assert-plus": {
-              "version": "0.1.5",
-              "from": "assert-plus@>=0.1.5 <0.2.0",
-              "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.1.5.tgz"
-            },
-            "asn1": {
-              "version": "0.1.11",
-              "from": "asn1@0.1.11",
-              "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.1.11.tgz"
-            },
-            "ctype": {
-              "version": "0.5.3",
-              "from": "ctype@0.5.3",
-              "resolved": "https://registry.npmjs.org/ctype/-/ctype-0.5.3.tgz"
+            "delayed-stream": {
+              "version": "1.0.0",
+              "from": "delayed-stream@>=1.0.0 <1.1.0",
+              "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz"
             }
           }
         },
-        "oauth-sign": {
-          "version": "0.3.0",
-          "from": "oauth-sign@>=0.3.0 <0.4.0",
-          "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.3.0.tgz"
+        "extend": {
+          "version": "3.0.0",
+          "from": "extend@>=3.0.0 <3.1.0",
+          "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.0.tgz"
+        },
+        "forever-agent": {
+          "version": "0.6.1",
+          "from": "forever-agent@>=0.6.1 <0.7.0",
+          "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz"
+        },
+        "form-data": {
+          "version": "2.0.0",
+          "from": "form-data@>=2.0.0 <2.1.0",
+          "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.0.0.tgz",
+          "dependencies": {
+            "asynckit": {
+              "version": "0.4.0",
+              "from": "asynckit@>=0.4.0 <0.5.0",
+              "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz"
+            }
+          }
+        },
+        "har-validator": {
+          "version": "2.0.6",
+          "from": "har-validator@>=2.0.6 <2.1.0",
+          "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-2.0.6.tgz",
+          "dependencies": {
+            "chalk": {
+              "version": "1.1.3",
+              "from": "chalk@>=1.1.1 <2.0.0",
+              "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+              "dependencies": {
+                "ansi-styles": {
+                  "version": "2.2.1",
+                  "from": "ansi-styles@>=2.2.1 <3.0.0",
+                  "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz"
+                },
+                "escape-string-regexp": {
+                  "version": "1.0.5",
+                  "from": "escape-string-regexp@>=1.0.2 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz"
+                },
+                "has-ansi": {
+                  "version": "2.0.0",
+                  "from": "has-ansi@>=2.0.0 <3.0.0",
+                  "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
+                  "dependencies": {
+                    "ansi-regex": {
+                      "version": "2.0.0",
+                      "from": "ansi-regex@>=2.0.0 <3.0.0",
+                      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
+                    }
+                  }
+                },
+                "strip-ansi": {
+                  "version": "3.0.1",
+                  "from": "strip-ansi@>=3.0.0 <4.0.0",
+                  "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+                  "dependencies": {
+                    "ansi-regex": {
+                      "version": "2.0.0",
+                      "from": "ansi-regex@>=2.0.0 <3.0.0",
+                      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
+                    }
+                  }
+                },
+                "supports-color": {
+                  "version": "2.0.0",
+                  "from": "supports-color@>=2.0.0 <3.0.0",
+                  "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
+                }
+              }
+            },
+            "commander": {
+              "version": "2.9.0",
+              "from": "commander@>=2.9.0 <3.0.0",
+              "resolved": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz",
+              "dependencies": {
+                "graceful-readlink": {
+                  "version": "1.0.1",
+                  "from": "graceful-readlink@>=1.0.0",
+                  "resolved": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz"
+                }
+              }
+            },
+            "is-my-json-valid": {
+              "version": "2.15.0",
+              "from": "is-my-json-valid@>=2.12.4 <3.0.0",
+              "resolved": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.15.0.tgz",
+              "dependencies": {
+                "generate-function": {
+                  "version": "2.0.0",
+                  "from": "generate-function@>=2.0.0 <3.0.0",
+                  "resolved": "https://registry.npmjs.org/generate-function/-/generate-function-2.0.0.tgz"
+                },
+                "generate-object-property": {
+                  "version": "1.2.0",
+                  "from": "generate-object-property@>=1.1.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/generate-object-property/-/generate-object-property-1.2.0.tgz",
+                  "dependencies": {
+                    "is-property": {
+                      "version": "1.0.2",
+                      "from": "is-property@>=1.0.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz"
+                    }
+                  }
+                },
+                "jsonpointer": {
+                  "version": "4.0.0",
+                  "from": "jsonpointer@>=4.0.0 <5.0.0",
+                  "resolved": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-4.0.0.tgz"
+                },
+                "xtend": {
+                  "version": "4.0.1",
+                  "from": "xtend@>=4.0.0 <5.0.0",
+                  "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz"
+                }
+              }
+            },
+            "pinkie-promise": {
+              "version": "2.0.1",
+              "from": "pinkie-promise@>=2.0.0 <3.0.0",
+              "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
+              "dependencies": {
+                "pinkie": {
+                  "version": "2.0.4",
+                  "from": "pinkie@>=2.0.0 <3.0.0",
+                  "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz"
+                }
+              }
+            }
+          }
         },
         "hawk": {
-          "version": "1.0.0",
-          "from": "hawk@>=1.0.0 <1.1.0",
-          "resolved": "https://registry.npmjs.org/hawk/-/hawk-1.0.0.tgz",
+          "version": "3.1.3",
+          "from": "hawk@>=3.1.3 <3.2.0",
+          "resolved": "https://registry.npmjs.org/hawk/-/hawk-3.1.3.tgz",
           "dependencies": {
             "hoek": {
-              "version": "0.9.1",
-              "from": "hoek@>=0.9.0 <0.10.0",
-              "resolved": "https://registry.npmjs.org/hoek/-/hoek-0.9.1.tgz"
+              "version": "2.16.3",
+              "from": "hoek@>=2.0.0 <3.0.0",
+              "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz"
             },
             "boom": {
-              "version": "0.4.2",
-              "from": "boom@>=0.4.0 <0.5.0",
-              "resolved": "https://registry.npmjs.org/boom/-/boom-0.4.2.tgz"
+              "version": "2.10.1",
+              "from": "boom@>=2.0.0 <3.0.0",
+              "resolved": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz"
             },
             "cryptiles": {
-              "version": "0.2.2",
-              "from": "cryptiles@>=0.2.0 <0.3.0",
-              "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-0.2.2.tgz"
+              "version": "2.0.5",
+              "from": "cryptiles@>=2.0.0 <3.0.0",
+              "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz"
             },
             "sntp": {
-              "version": "0.2.4",
-              "from": "sntp@>=0.2.0 <0.3.0",
-              "resolved": "https://registry.npmjs.org/sntp/-/sntp-0.2.4.tgz"
+              "version": "1.0.9",
+              "from": "sntp@>=1.0.0 <2.0.0",
+              "resolved": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz"
             }
           }
         },
-        "aws-sign2": {
-          "version": "0.5.0",
-          "from": "aws-sign2@>=0.5.0 <0.6.0",
-          "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.5.0.tgz"
+        "http-signature": {
+          "version": "1.1.1",
+          "from": "http-signature@>=1.1.0 <1.2.0",
+          "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.1.1.tgz",
+          "dependencies": {
+            "assert-plus": {
+              "version": "0.2.0",
+              "from": "assert-plus@>=0.2.0 <0.3.0",
+              "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.2.0.tgz"
+            },
+            "jsprim": {
+              "version": "1.3.1",
+              "from": "jsprim@>=1.2.2 <2.0.0",
+              "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.3.1.tgz",
+              "dependencies": {
+                "extsprintf": {
+                  "version": "1.0.2",
+                  "from": "extsprintf@1.0.2",
+                  "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.0.2.tgz"
+                },
+                "json-schema": {
+                  "version": "0.2.3",
+                  "from": "json-schema@0.2.3",
+                  "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz"
+                },
+                "verror": {
+                  "version": "1.3.6",
+                  "from": "verror@1.3.6",
+                  "resolved": "https://registry.npmjs.org/verror/-/verror-1.3.6.tgz"
+                }
+              }
+            },
+            "sshpk": {
+              "version": "1.10.1",
+              "from": "sshpk@>=1.7.0 <2.0.0",
+              "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.10.1.tgz",
+              "dependencies": {
+                "asn1": {
+                  "version": "0.2.3",
+                  "from": "asn1@>=0.2.3 <0.3.0",
+                  "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.3.tgz"
+                },
+                "assert-plus": {
+                  "version": "1.0.0",
+                  "from": "assert-plus@>=1.0.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz"
+                },
+                "dashdash": {
+                  "version": "1.14.0",
+                  "from": "dashdash@>=1.12.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.0.tgz"
+                },
+                "getpass": {
+                  "version": "0.1.6",
+                  "from": "getpass@>=0.1.1 <0.2.0",
+                  "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.6.tgz"
+                },
+                "jsbn": {
+                  "version": "0.1.0",
+                  "from": "jsbn@>=0.1.0 <0.2.0",
+                  "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.0.tgz"
+                },
+                "tweetnacl": {
+                  "version": "0.14.3",
+                  "from": "tweetnacl@>=0.14.0 <0.15.0",
+                  "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.3.tgz"
+                },
+                "jodid25519": {
+                  "version": "1.0.2",
+                  "from": "jodid25519@>=1.0.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/jodid25519/-/jodid25519-1.0.2.tgz"
+                },
+                "ecc-jsbn": {
+                  "version": "0.1.1",
+                  "from": "ecc-jsbn@>=0.1.1 <0.2.0",
+                  "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz"
+                },
+                "bcrypt-pbkdf": {
+                  "version": "1.0.0",
+                  "from": "bcrypt-pbkdf@>=1.0.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.0.tgz"
+                }
+              }
+            }
+          }
+        },
+        "is-typedarray": {
+          "version": "1.0.0",
+          "from": "is-typedarray@>=1.0.0 <1.1.0",
+          "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz"
+        },
+        "isstream": {
+          "version": "0.1.2",
+          "from": "isstream@>=0.1.2 <0.2.0",
+          "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz"
+        },
+        "json-stringify-safe": {
+          "version": "5.0.1",
+          "from": "json-stringify-safe@>=5.0.1 <5.1.0",
+          "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz"
+        },
+        "mime-types": {
+          "version": "2.1.12",
+          "from": "mime-types@>=2.1.7 <2.2.0",
+          "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.12.tgz",
+          "dependencies": {
+            "mime-db": {
+              "version": "1.24.0",
+              "from": "mime-db@>=1.24.0 <1.25.0",
+              "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.24.0.tgz"
+            }
+          }
+        },
+        "node-uuid": {
+          "version": "1.4.7",
+          "from": "node-uuid@>=1.4.7 <1.5.0",
+          "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.7.tgz"
+        },
+        "oauth-sign": {
+          "version": "0.8.2",
+          "from": "oauth-sign@>=0.8.1 <0.9.0",
+          "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.2.tgz"
+        },
+        "qs": {
+          "version": "6.2.1",
+          "from": "qs@>=6.2.0 <6.3.0",
+          "resolved": "https://registry.npmjs.org/qs/-/qs-6.2.1.tgz"
+        },
+        "stringstream": {
+          "version": "0.0.5",
+          "from": "stringstream@>=0.0.4 <0.1.0",
+          "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz"
+        },
+        "tough-cookie": {
+          "version": "2.3.1",
+          "from": "tough-cookie@>=2.3.0 <2.4.0",
+          "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.1.tgz"
+        },
+        "tunnel-agent": {
+          "version": "0.4.3",
+          "from": "tunnel-agent@>=0.4.1 <0.5.0",
+          "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.3.tgz"
         }
       }
     },
     "should": {
-      "version": "4.0.0",
-      "from": "should@4.0.0",
-      "resolved": "https://registry.npmjs.org/should/-/should-4.0.0.tgz"
+      "version": "11.1.0",
+      "from": "should@11.1.0",
+      "resolved": "https://registry.npmjs.org/should/-/should-11.1.0.tgz",
+      "dependencies": {
+        "should-equal": {
+          "version": "1.0.1",
+          "from": "should-equal@>=1.0.0 <2.0.0",
+          "resolved": "https://registry.npmjs.org/should-equal/-/should-equal-1.0.1.tgz"
+        },
+        "should-format": {
+          "version": "3.0.2",
+          "from": "should-format@>=3.0.1 <4.0.0",
+          "resolved": "https://registry.npmjs.org/should-format/-/should-format-3.0.2.tgz"
+        },
+        "should-type": {
+          "version": "1.4.0",
+          "from": "should-type@>=1.4.0 <2.0.0",
+          "resolved": "https://registry.npmjs.org/should-type/-/should-type-1.4.0.tgz"
+        },
+        "should-type-adaptors": {
+          "version": "1.0.1",
+          "from": "should-type-adaptors@>=1.0.0 <2.0.0",
+          "resolved": "https://registry.npmjs.org/should-type-adaptors/-/should-type-adaptors-1.0.1.tgz"
+        },
+        "should-util": {
+          "version": "1.0.0",
+          "from": "should-util@>=1.0.0 <2.0.0",
+          "resolved": "https://registry.npmjs.org/should-util/-/should-util-1.0.0.tgz"
+        }
+      }
     },
     "temp": {
-      "version": "0.7.0",
-      "from": "temp@0.7.0",
-      "resolved": "https://registry.npmjs.org/temp/-/temp-0.7.0.tgz",
+      "version": "0.8.3",
+      "from": "temp@0.8.3",
+      "resolved": "https://registry.npmjs.org/temp/-/temp-0.8.3.tgz",
       "dependencies": {
+        "os-tmpdir": {
+          "version": "1.0.2",
+          "from": "os-tmpdir@>=1.0.0 <2.0.0",
+          "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz"
+        },
         "rimraf": {
           "version": "2.2.8",
           "from": "rimraf@>=2.2.6 <2.3.0",
@@ -2262,14 +3241,14 @@
       "resolved": "git://github.com/strml/node-toobusy.git#ed8b8bb6909a82ae3007940cd5ac42f0488b00ab"
     },
     "underscore": {
-      "version": "1.7.0",
-      "from": "underscore@1.7.0",
-      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.7.0.tgz"
+      "version": "1.8.3",
+      "from": "underscore@1.8.3",
+      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.8.3.tgz"
     },
     "walk": {
-      "version": "2.3.3",
-      "from": "walk@2.3.3",
-      "resolved": "https://registry.npmjs.org/walk/-/walk-2.3.3.tgz",
+      "version": "2.3.9",
+      "from": "walk@2.3.9",
+      "resolved": "https://registry.npmjs.org/walk/-/walk-2.3.9.tgz",
       "dependencies": {
         "foreachasync": {
           "version": "3.0.0",

--- a/package.json
+++ b/package.json
@@ -15,24 +15,26 @@
     "node": ">=0.10.0"
   },
   "dependencies": {
-    "async": "0.9.0",
-    "browserid-local-verify": "0.3.2",
+    "async": "2.0.1",
+    "body-parser": "1.15.2",
+    "browserid-local-verify": "0.5.0",
     "compute-cluster": "0.0.9",
-    "convict": "1.1.2",
-    "express": "3.8.1",
-    "intel": "0.5.2",
+    "convict": "1.5.0",
+    "express": "4.14.0",
+    "intel": "1.1.1",
+    "morgan": "1.7.0",
     "optimist": "0.6.1",
     "toobusy-js": "strml/node-toobusy#ed8b8bb6909a82ae3007940cd5ac42f0488b00ab",
-    "underscore": "1.7.0"
+    "underscore": "1.8.3"
   },
   "devDependencies": {
     "ass": "git://github.com/jrgm/ass.git#5be99ee7abc9fcf63f9ebcc37b151b9c822146d1",
-    "jshint": "2.5.1",
-    "mocha": "1.20.0",
-    "request": "2.36.0",
-    "should": "4.0.0",
-    "temp": "0.7.0",
-    "walk": "2.3.3"
+    "jshint": "2.9.3",
+    "mocha": "3.1.0",
+    "request": "2.75.0",
+    "should": "11.1.0",
+    "temp": "0.8.3",
+    "walk": "2.3.9"
   },
   "scripts": {
     "test": "mocha -t 5000 -R spec tests/*.js"

--- a/tests/cascading-config.js
+++ b/tests/cascading-config.js
@@ -4,9 +4,10 @@
 
 /* global describe,it,require */
 
+require('should');
+
 var
 Verifier = require('./lib/verifier.js'),
-should = require('should'),
 async = require('async'),
 temp = require('temp'),
 fs = require('fs');

--- a/tests/health-check.js
+++ b/tests/health-check.js
@@ -4,9 +4,10 @@
 
 /* global describe,it,require */
 
+require('should');
+
 var
 Verifier = require('./lib/verifier.js'),
-should = require('should'),
 request = require('request');
 
 describe('health check', function() {

--- a/tests/logging.js
+++ b/tests/logging.js
@@ -15,9 +15,8 @@ describe('custom log formatter', function() {
     var output = [];
     var handler = new intel.handlers.Stream({
       stream: {
-        write: function(data, cb) {
+        write: function(data) {
           output.push(JSON.parse(data));
-          cb();
         }
       }
     });
@@ -25,14 +24,12 @@ describe('custom log formatter', function() {
     var log = intel.getLogger('bid.test');
     log.setLevel(log.DEBUG).addHandler(handler);
     log.propagate = false;
-    log.debug('hello world').then(function() {
-      log.debug({'field': 'value'}).then(function() {
-        should(output[0].message).equal('hello world');
-        should(output[1].field).equal('value');
-        should.not.exist(output[1].message);
-        done();
-      });
-    });
+    log.debug('hello world');
+    log.debug({'field': 'value'});
+    should(output[0].message).equal('hello world');
+    should(output[1].field).equal('value');
+    should.not.exist(output[1].message);
+    done();
   });
 
 });


### PR DESCRIPTION
This updates to newer verions of dependencies, in order to silence many NSP warnings.  It needs to wait for a new version of browserid-local-verify to be deployed with https://github.com/mozilla/browserid-local-verify/pull/45.

/cc @jrgm, although no r? yet due to the above.