### PR TITLE
feat(security): add xss, sts, content type, and frame option headers

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -41,6 +41,22 @@ function shutdown(signal) {
   process.on(signal, shutdown(signal.substr(3)));
 });
 
+// header manipulation
+app.use(function(req, res, next) {
+  // no caching allowed, this is an API server.
+  res.setHeader('Cache-Control', 'private, no-cache, no-store, must-revalidate, max-age=0');
+
+  // security headers
+  res.setHeader('X-XSS-Protection', '1; mode=block');
+  res.setHeader('X-Content-Type-Options', 'nosniff');
+  res.setHeader('X-Frame-Options', 'DENY');
+  res.setHeader('Strict-Transport-Security', 'max-age=15552000');
+
+  // shave some needless bytes
+  res.removeHeader('X-Powered-By');
+  res.setHeader('Connection', "close");
+  next();
+});
 
 // health check - registered before all other middleware.
 app.use(function(req, res, next) {
@@ -76,16 +92,6 @@ app.use(morgan('common', {
     }
   }
 }));
-
-// header manipulation
-app.use(function(req, res, next) {
-  // no caching allowed, this is an API server.
-  res.setHeader('Cache-Control', 'no-cache, max-age=0');
-  // shave some needless bytes
-  res.removeHeader('X-Powered-By');
-  res.setHeader('Connection', "close");
-  next();
-});
 
 // log summary - GH24
 app.use(summary());

--- a/lib/server.js
+++ b/lib/server.js
@@ -54,7 +54,7 @@ app.use(function(req, res, next) {
 
   // shave some needless bytes
   res.removeHeader('X-Powered-By');
-  res.setHeader('Connection', "close");
+  res.setHeader('Connection', 'close');
   next();
 });
 

--- a/tests/audience.js
+++ b/tests/audience.js
@@ -9,6 +9,7 @@ IdP = require('browserid-local-verify/testing').IdP,
 Client = require('browserid-local-verify/testing').Client,
 Verifier = require('./lib/verifier.js'),
 should = require('should'),
+shouldReturnSecurityHeaders = require('./lib/should-return-security-headers.js'),
 request = require('request');
 
 describe('audience tests', function() {
@@ -50,6 +51,7 @@ describe('audience tests', function() {
     submitWithAudience('http://example.com', function(err, r) {
       should.not.exist(err);
       ('okay').should.equal(r.body.status);
+      shouldReturnSecurityHeaders(r);
       done();
     });
   });
@@ -59,6 +61,7 @@ describe('audience tests', function() {
       should.not.exist(err);
       (r.body.status).should.equal('failure');
       (r.body.reason).should.equal('audience mismatch: domain mismatch');
+      shouldReturnSecurityHeaders(r);
       done(err);
     });
   });
@@ -68,6 +71,7 @@ describe('audience tests', function() {
       should.not.exist(err);
       (r.body.status).should.equal('failure');
       (r.body.reason).should.equal('audience mismatch: port mismatch');
+      shouldReturnSecurityHeaders(r);
       done(err);
     });
   });
@@ -77,6 +81,7 @@ describe('audience tests', function() {
       should.not.exist(err);
       (r.body.status).should.equal('failure');
       (r.body.reason).should.equal('audience mismatch: scheme mismatch');
+      shouldReturnSecurityHeaders(r);
       done(err);
     });
   });
@@ -86,6 +91,7 @@ describe('audience tests', function() {
       should.not.exist(err);
       (r.body.status).should.equal('failure');
       (r.body.reason).should.equal('missing audience parameter');
+      shouldReturnSecurityHeaders(r);
       done(err);
     });
   });

--- a/tests/basic.js
+++ b/tests/basic.js
@@ -9,7 +9,9 @@ IdP = require('browserid-local-verify/testing').IdP,
 Client = require('browserid-local-verify/testing').Client,
 Verifier = require('./lib/verifier.js'),
 should = require('should'),
+shouldReturnSecurityHeaders = require('./lib/should-return-security-headers.js'),
 request = require('request');
+
 
 describe('basic verifier test', function() {
   var idp = new IdP();
@@ -44,6 +46,7 @@ describe('basic verifier test', function() {
         (r.body.status).should.equal('okay');
         (r.body.audience).should.equal('http://example.com');
         (r.statusCode).should.equal(200);
+        shouldReturnSecurityHeaders(r);
         done();
       });
     });
@@ -56,6 +59,7 @@ describe('basic verifier test', function() {
     }, function(err, r) {
       should.not.exist(err);
       (r.statusCode).should.equal(405);
+      shouldReturnSecurityHeaders(r);
       done();
     });
   });
@@ -69,6 +73,7 @@ describe('basic verifier test', function() {
     }, function(err, r) {
       should.not.exist(err);
       (r.statusCode).should.equal(400);
+      shouldReturnSecurityHeaders(r);
       done();
     });
   });

--- a/tests/content-type.js
+++ b/tests/content-type.js
@@ -9,6 +9,7 @@ IdP = require('browserid-local-verify/testing').IdP,
 Client = require('browserid-local-verify/testing').Client,
 Verifier = require('./lib/verifier.js'),
 should = require('should'),
+shouldReturnSecurityHeaders = require('./lib/should-return-security-headers.js'),
 request = require('request');
 
 describe('content-type tests', function() {
@@ -49,6 +50,7 @@ describe('content-type tests', function() {
       }).should.not.throw();
       (r.body.status).should.equal('failure');
       (r.body.reason).should.startWith('Unsupported Content-Type: text/plain');
+      shouldReturnSecurityHeaders(r);
       done();
     });
   });
@@ -66,6 +68,7 @@ describe('content-type tests', function() {
       }).should.not.throw();
       (r.body.status).should.equal('failure');
       (r.body.reason).should.startWith('Unsupported Content-Type: none');
+      shouldReturnSecurityHeaders(r);
       done();
     });
   });
@@ -85,6 +88,7 @@ describe('content-type tests', function() {
       }).should.not.throw();
       (r.body.status).should.equal('failure');
       (r.body.reason).should.startWith('Unsupported Content-Type: text/plain');
+      shouldReturnSecurityHeaders(r);
       done();
     });
   });
@@ -102,6 +106,7 @@ describe('content-type tests', function() {
       }).should.not.throw();
       (r.body.status).should.equal('failure');
       (r.body.reason).should.startWith('Unsupported Content-Type: none');
+      shouldReturnSecurityHeaders(r);
       done();
     });
   });
@@ -123,6 +128,7 @@ describe('content-type tests', function() {
         r.body = JSON.parse(r.body);
       }).should.not.throw();
       (r.body.status).should.equal('failure');
+      shouldReturnSecurityHeaders(r);
       done();
     });
   });
@@ -144,6 +150,7 @@ describe('content-type tests', function() {
         r.body = JSON.parse(r.body);
       }).should.not.throw();
       (r.body.status).should.equal('failure');
+      shouldReturnSecurityHeaders(r);
       done();
     });
   });
@@ -166,6 +173,7 @@ describe('content-type tests', function() {
       }).should.not.throw();
       (r.body.status).should.equal('failure');
       r.body.reason.should.startWith('Unsupported Content-Type');
+      shouldReturnSecurityHeaders(r);
       done();
     });
   });
@@ -188,6 +196,7 @@ describe('content-type tests', function() {
       }).should.not.throw();
       (r.body.status).should.equal('failure');
       r.body.reason.should.startWith('missing audience');
+      shouldReturnSecurityHeaders(r);
       done();
     });
   });

--- a/tests/fallback.js
+++ b/tests/fallback.js
@@ -9,6 +9,7 @@ IdP = require('browserid-local-verify/testing').IdP,
 Client = require('browserid-local-verify/testing').Client,
 Verifier = require('./lib/verifier.js'),
 should = require('should'),
+shouldReturnSecurityHeaders = require('./lib/should-return-security-headers.js'),
 request = require('request');
 
 describe('fallback configuration test', function() {
@@ -49,6 +50,7 @@ describe('fallback configuration test', function() {
         (r.body.issuer).should.equal(idp.domain());
         (r.body.audience).should.equal('http://rp.example.com');
         (r.statusCode).should.equal(200);
+        shouldReturnSecurityHeaders(r);
         done();
       });
     });
@@ -87,6 +89,7 @@ describe('fallback configuration test', function() {
         (r.body.status).should.equal('failure');
         // XXX: better error message
         (r.body.reason).should.startWith("untrusted issuer");
+        shouldReturnSecurityHeaders(r);
         done();
       });
     });

--- a/tests/force-issuer.js
+++ b/tests/force-issuer.js
@@ -9,6 +9,7 @@ IdP = require('browserid-local-verify/testing').IdP,
 Client = require('browserid-local-verify/testing').Client,
 Verifier = require('./lib/verifier.js'),
 should = require('should'),
+shouldReturnSecurityHeaders = require('./lib/should-return-security-headers.js'),
 request = require('request');
 
 describe('force issuer', function() {
@@ -50,6 +51,7 @@ describe('force issuer', function() {
         (r.statusCode).should.equal(200);
         (r.body.status).should.equal('failure');
         (r.body.reason).should.startWith("untrusted issuer");
+        shouldReturnSecurityHeaders(r);
         done();
       });
     });
@@ -76,6 +78,7 @@ describe('force issuer', function() {
         should.not.exist(err);
         (r.statusCode).should.equal(200);
         (r.body.status).should.equal('okay');
+        shouldReturnSecurityHeaders(r);
         done();
       });
     });
@@ -102,6 +105,7 @@ describe('force issuer', function() {
         should.not.exist(err);
         (r.statusCode).should.equal(200);
         (r.body.status).should.equal('okay');
+        shouldReturnSecurityHeaders(r);
         done();
       });
     });

--- a/tests/health-check.js
+++ b/tests/health-check.js
@@ -8,6 +8,7 @@ require('should');
 
 var
 Verifier = require('./lib/verifier.js'),
+shouldReturnSecurityHeaders = require('./lib/should-return-security-headers.js'),
 request = require('request');
 
 describe('health check', function() {
@@ -23,6 +24,7 @@ describe('health check', function() {
     }, function(err, r) {
       (r.statusCode).should.equal(200);
       (r.body).should.equal('OK');
+      shouldReturnSecurityHeaders(r);
       done(err);
     });
   });

--- a/tests/lib/should-return-security-headers.js
+++ b/tests/lib/should-return-security-headers.js
@@ -1,0 +1,22 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+var should = require('should');
+
+function shouldReturnSecurityHeaders(res) {
+  var expect = {
+    'strict-transport-security': 'max-age=15552000',
+    'x-content-type-options': 'nosniff',
+    'x-xss-protection': '1; mode=block',
+    'x-frame-options': 'DENY',
+    'cache-control': 'private, no-cache, no-store, must-revalidate, max-age=0'
+  };
+
+  Object.keys(expect).forEach(function(header) {
+    should.exist(res.headers[header]);
+    (res.headers[header]).should.equal(expect[header]);
+  });
+}
+
+module.exports = shouldReturnSecurityHeaders;

--- a/tests/missing-assertion.js
+++ b/tests/missing-assertion.js
@@ -7,6 +7,7 @@
 var
 Verifier = require('./lib/verifier.js'),
 should = require('should'),
+shouldReturnSecurityHeaders = require('./lib/should-return-security-headers.js'),
 request = require('request');
 
 describe('missing assertion test', function() {
@@ -29,6 +30,7 @@ describe('missing assertion test', function() {
       (r.statusCode).should.equal(400);
       (r.body.status).should.equal('failure');
       (r.body.reason).should.equal('missing assertion parameter');
+      shouldReturnSecurityHeaders(r);
       done();
     });
   });

--- a/tests/service-failure.js
+++ b/tests/service-failure.js
@@ -9,6 +9,7 @@ IdP = require('browserid-local-verify/testing').IdP,
 Client = require('browserid-local-verify/testing').Client,
 Verifier = require('./lib/verifier.js'),
 should = require('should'),
+shouldReturnSecurityHeaders = require('./lib/should-return-security-headers.js'),
 request = require('request');
 
 describe('audience tests', function() {
@@ -47,6 +48,7 @@ describe('audience tests', function() {
       should.not.exist(err);
       (503).should.equal(r.statusCode);
       ('failure').should.equal(r.body.status);
+      shouldReturnSecurityHeaders(r);
       done();
     });
   });
@@ -64,6 +66,7 @@ describe('audience tests', function() {
       should.not.exist(err);
       (503).should.equal(r.statusCode);
       ('failure').should.equal(r.body.status);
+      shouldReturnSecurityHeaders(r);
       done();
     });
   });

--- a/tests/trusted-issuers.js
+++ b/tests/trusted-issuers.js
@@ -9,6 +9,7 @@ IdP = require('browserid-local-verify/testing').IdP,
 Client = require('browserid-local-verify/testing').Client,
 Verifier = require('./lib/verifier.js'),
 should = require('should'),
+shouldReturnSecurityHeaders = require('./lib/should-return-security-headers.js'),
 request = require('request');
 
 describe('audience tests', function() {
@@ -56,6 +57,7 @@ describe('audience tests', function() {
     submitWithTrustedIssuers([ idp.domain() ], function(err, r) {
       should.not.exist(err);
       ('okay').should.equal(r.body.status);
+      shouldReturnSecurityHeaders(r);
       done();
     });
   });
@@ -64,6 +66,7 @@ describe('audience tests', function() {
     submitWithTrustedIssuers(undefined, function(err, r) {
       should.not.exist(err);
       ('failure').should.equal(r.body.status);
+      shouldReturnSecurityHeaders(r);
       done();
     });
   });
@@ -73,6 +76,7 @@ describe('audience tests', function() {
       should.not.exist(err);
       ('failure').should.equal(r.body.status);
       ('trusted issuers must be an array').should.equal(r.body.reason);
+      shouldReturnSecurityHeaders(r);
       done();
     });
   });
@@ -82,6 +86,7 @@ describe('audience tests', function() {
       should.not.exist(err);
       ('failure').should.equal(r.body.status);
       ('trusted issuers must be an array of strings').should.equal(r.body.reason);
+      shouldReturnSecurityHeaders(r);
       done();
     });
   });

--- a/tests/unverified-email.js
+++ b/tests/unverified-email.js
@@ -9,6 +9,7 @@ IdP = require('browserid-local-verify/testing').IdP,
 Client = require('browserid-local-verify/testing').Client,
 Verifier = require('./lib/verifier.js'),
 should = require('should'),
+shouldReturnSecurityHeaders = require('./lib/should-return-security-headers.js'),
 request = require('request');
 
 describe('unverified email', function() {
@@ -46,6 +47,7 @@ describe('unverified email', function() {
         (r.statusCode).should.equal(200);
         (r.body.status).should.equal('failure');
         (r.body.reason).should.startWith("untrusted assertion");
+        shouldReturnSecurityHeaders(r);
         done();
       });
     });
@@ -72,6 +74,7 @@ describe('unverified email', function() {
         (r.body.idpClaims).should.be.type('object');
         (r.body.idpClaims["unverified-email"]).should.equal('bob@example.com');
         (r.body).should.not.have.property("unverified-email");
+        shouldReturnSecurityHeaders(r);
         done();
       });
     });
@@ -100,6 +103,7 @@ describe('unverified email', function() {
         (r.body.idpClaims).should.be.type('object');
         (r.body.idpClaims["unverified-email"]).should.equal('bob@example.com');
         (r.body).should.have.property("unverified-email");
+        shouldReturnSecurityHeaders(r);
         done();
       });
     });


### PR DESCRIPTION
and return headers with all responses

similar to: https://github.com/mozilla/fxa-profile-server/pull/231

We could return the STS header from nginx if it breaks local testing with a browser. 