### PR TITLE
feat(security): Add CSP header for web APIs

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -51,6 +51,7 @@ app.use(function(req, res, next) {
   res.setHeader('X-Content-Type-Options', 'nosniff');
   res.setHeader('X-Frame-Options', 'DENY');
   res.setHeader('Strict-Transport-Security', 'max-age=15552000');
+  res.setHeader('Content-Security-Policy', 'default-src: \'none\'; frame-ancestors: \'none\'; report-uri: /__cspreport__');
 
   // shave some needless bytes
   res.removeHeader('X-Powered-By');

--- a/tests/lib/should-return-security-headers.js
+++ b/tests/lib/should-return-security-headers.js
@@ -10,7 +10,8 @@ function shouldReturnSecurityHeaders(res) {
     'x-content-type-options': 'nosniff',
     'x-xss-protection': '1; mode=block',
     'x-frame-options': 'DENY',
-    'cache-control': 'private, no-cache, no-store, must-revalidate, max-age=0'
+    'cache-control': 'private, no-cache, no-store, must-revalidate, max-age=0',
+    'content-security-policy': 'default-src: \'none\'; frame-ancestors: \'none\'; report-uri: /__cspreport__'
   };
 
   Object.keys(expect).forEach(function(header) {


### PR DESCRIPTION
Adds [the recommended CSP header for Web APIs](https://wiki.mozilla.org/Security/Guidelines/Web_Security#Content_Security_Policy) (since this service doesn't return HTML as far as I can tell) with the default csp report endpoint.

should've included this in: #89

refs: https://github.com/mozilla-services/foxsec/issues/177