### PR TITLE
fix(security): Remove colons from CSP header

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -51,7 +51,7 @@ app.use(function(req, res, next) {
   res.setHeader('X-Content-Type-Options', 'nosniff');
   res.setHeader('X-Frame-Options', 'DENY');
   res.setHeader('Strict-Transport-Security', 'max-age=15552000');
-  res.setHeader('Content-Security-Policy', 'default-src: \'none\'; frame-ancestors: \'none\'; report-uri: /__cspreport__');
+  res.setHeader('Content-Security-Policy', 'default-src \'none\'; frame-ancestors \'none\'; report-uri /__cspreport__');
 
   // shave some needless bytes
   res.removeHeader('X-Powered-By');

--- a/tests/lib/should-return-security-headers.js
+++ b/tests/lib/should-return-security-headers.js
@@ -11,7 +11,7 @@ function shouldReturnSecurityHeaders(res) {
     'x-xss-protection': '1; mode=block',
     'x-frame-options': 'DENY',
     'cache-control': 'private, no-cache, no-store, must-revalidate, max-age=0',
-    'content-security-policy': 'default-src: \'none\'; frame-ancestors: \'none\'; report-uri: /__cspreport__'
+    'content-security-policy': 'default-src \'none\'; frame-ancestors \'none\'; report-uri /__cspreport__'
   };
 
   Object.keys(expect).forEach(function(header) {


### PR DESCRIPTION
refs: https://github.com/mozilla-services/foxsec/issues/177

Apparently I can't make a two line change without introducing bugs.

Fixes errors:

```
Content Security Policy: Couldn’t process unknown directive ‘default-src:’
Content Security Policy: Couldn’t process unknown directive ‘frame-ancestors:’
Content Security Policy: Couldn’t process unknown directive ‘report-uri:’
```

with #90. 

<img width="1106" alt="screen shot 2017-03-15 at 3 25 34 pm" src="https://cloud.githubusercontent.com/assets/226605/23967005/c0718c5c-0993-11e7-8a99-f4ed0d76c74e.png">

Functional Test:

- [x] run `./server.js` and open / on this branch and do not get CSP errors