### PR TITLE
fix(travis): run tests with {4,6,8}

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,8 @@ language: node_js
 
 node_js:
  - "4"
+ - "6"
+ - "8"
 
 addons:
   apt_packages:


### PR DESCRIPTION
Keeping 4 since the Dockerfile is still on 4, but adding 6 and 8

r? - @rfk, @vladikoff 