### PR TITLE
feat(lookup): Allow forcing lookup over http, for testing purposes.

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -36,6 +36,12 @@ function loadConf() {
       default: false,
       env: "INSECURE_SSL"
     },
+    forceInsecureLookupOverHTTP: {
+      doc: "(testing only) Lookup /.well-known/browserid documents over HTTP",
+      format: Boolean,
+      default: false,
+      env: "FORCE_INSECURE_LOOKUP_OVER_HTTP"
+    },
     toobusy: {
       maxLag: {
         doc: "Max event-loop lag before toobusy reports failure",

--- a/lib/server.js
+++ b/lib/server.js
@@ -24,6 +24,7 @@ var server = http.createServer(app);
 var verifier = new CCVerifier({
   httpTimeout: config.get('httpTimeout'),
   insecureSSL: config.get('insecureSSL'),
+  forceInsecureLookupOverHTTP: config.get('forceInsecureLookupOverHTTP'),
   testServiceFailure: config.get('testServiceFailure')
 });
 

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -296,8 +296,8 @@
       }
     },
     "browserid-local-verify": {
-      "version": "0.5.0",
-      "from": "browserid-local-verify@0.5.0",
+      "version": "0.5.1",
+      "from": "browserid-local-verify@0.5.1",
       "resolved": "https://registry.npmjs.org/browserid-local-verify/-/browserid-local-verify-0.5.0.tgz",
       "dependencies": {
         "browserid-crypto": {

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   "dependencies": {
     "async": "2.0.1",
     "body-parser": "1.18.2",
-    "browserid-local-verify": "0.5.0",
+    "browserid-local-verify": "0.5.1",
     "compute-cluster": "0.0.9",
     "convict": "1.5.0",
     "express": "4.15.5",


### PR DESCRIPTION
Fixes https://github.com/mozilla/browserid-verifier/issues/106 and depends on https://github.com/mozilla/browserid-local-verify/pull/47