### PR TITLE
fix(logging): correctly log request information

### DIFF
--- a/lib/summary.js
+++ b/lib/summary.js
@@ -15,7 +15,7 @@ module.exports = function middlewareFactory() {
       var summary = res._summary;
       summary.code = res.statusCode;
 
-      logger.info(summary);
+      logger.info('info', summary);
     }
 
     res._summary = {};


### PR DESCRIPTION
fixes #140 ?

r? - @rfk 

Not sure what I should have named it, but `info` may be good enough.